### PR TITLE
 fix for ubuntu sid sometimes linking /bin/sh to /bin/dash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 # Script to build the kafka-connect-irc connector and move them to the plugin path directory
 export PLUGINPATH:="connect-plugins"
+# fix for ubuntu sid sometimes linking /bin/sh to /bin/dash
+SHELL:=/bin/bash
 
 all: install irc transform
 


### PR DESCRIPTION
Fix for:
~/Code/cp-demo$ make
if [[ ! -d "connect-plugins" ]]; then mkdir "connect-plugins"; fi
/bin/sh: 1: [[: not found
make install
make[1]: Entering directory '/home/mitchellh/Code/cp-demo'
if [[ ! -d "connect-plugins" ]]; then mkdir "connect-plugins"; fi
/bin/sh: 1: [[: not found
make[1]: Leaving directory '/home/mitchellh/Code/cp-demo'
mvn clean package -f kafka-connect-irc/pom.xml
[INFO] Scanning for projects...