### PR TITLE
improve stop.sh for deleting volumes

### DIFF
--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -4,7 +4,6 @@ ps aux | grep ksql-server-start | grep -v "grep ksql" | awk '{print $2}' | xargs
 
 docker-compose down
 
-volumes=$(docker volume ls -q --filter="dangling=true")
-if [ -n "$volumes" ]; then
-	docker volumes rm "$volumes"
-fi
+for v in $(docker volume ls -q --filter="dangling=true"); do
+	docker volume rm "$v"
+done

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -3,4 +3,8 @@
 ps aux | grep ksql-server-start | grep -v "grep ksql" | awk '{print $2}' | xargs kill -15
 
 docker-compose down
-docker volume ls -q --filter dangling=true | xargs -r docker volume rm
+
+volumes=$(docker volume ls -q --filter="dangling=true")
+if [ -n "$volumes" ]; then
+	docker volumes rm "$volumes"
+fi

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -3,4 +3,4 @@
 ps aux | grep ksql-server-start | grep -v "grep ksql" | awk '{print $2}' | xargs kill -15
 
 docker-compose down
-docker volume ls -q --filter dangling=true | xargs docker volume rm
+docker volume ls -q --filter dangling=true | xargs -r docker volume rm


### PR DESCRIPTION
if 'docker ls' returns no volumes (cause you already stopped and cleaned everything) you cannot start cp-demo again, because start.sh is using stop.sh which is going to fail on xargs command with no (null) param.