### PR TITLE
Change partitions count on downstream topic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,7 +332,7 @@ services:
                        cub kafka-ready -b kafka1:9091 1 60 --config /etc/kafka/kafka.properties && \
                        sleep 5 && \
                        kafka-topics --zookeeper zookeeper:2181 --topic wikipedia.parsed --create --replication-factor 2 --partitions 2 && \
-                       kafka-topics --zookeeper zookeeper:2181 --topic wikipedia.parsed.replica --create --replication-factor 2 --partitions 4 && \
+                       kafka-topics --zookeeper zookeeper:2181 --topic wikipedia.parsed.replica --create --replication-factor 2 --partitions 2 && \
                        kafka-topics --zookeeper zookeeper:2181 --topic wikipedia.failed --create --replication-factor 2 --partitions 2 && \
                        kafka-topics --zookeeper zookeeper:2181 --topic WIKIPEDIABOT --create --replication-factor 2 --partitions 2 && \
                        kafka-topics --zookeeper zookeeper:2181 --topic WIKIPEDIANOBOT --create --replication-factor 2 --partitions 2 && \


### PR DESCRIPTION
Partition change to downstream topic, changed from 4 to 2, as this is the same value of the upstream topic.
We have the preserve partitions flag on, any changes on the upstream partitions count will be changed on the downstream.