### PR TITLE
#45: fix run script for linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: confluentinc/cp-zookeeper:4.1.0
     restart: always
     hostname: zookeeper
+    container_name: zookeeper
     environment:
       ZOOKEEPER_SERVER_ID: 1
       ZOOKEEPER_CLIENT_PORT: "2181"
@@ -17,6 +18,7 @@ services:
   kafka1:
     image: confluentinc/cp-enterprise-kafka:4.1.0
     hostname: kafka1
+    container_name: kafka1
     depends_on:
       - zookeeper
     volumes:
@@ -68,6 +70,7 @@ services:
   kafka2:
     image: confluentinc/cp-enterprise-kafka:4.1.0
     hostname: kafka2
+    container_name: kafka2
     depends_on:
       - zookeeper
     volumes:
@@ -118,6 +121,7 @@ services:
       KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/secrets/broker_jaas.conf
   connect:
     image: confluentinc/cp-kafka-connect:4.1.0
+    container_name: connect
     restart: always
     ports:
       - "8083:8083"
@@ -215,6 +219,7 @@ services:
                   -Djavax.net.ssl.keyStorePassword=confluent
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.0
+    container_name: elasticsearch
     #restart: always
     depends_on:
       - connect
@@ -226,6 +231,7 @@ services:
       ES_JAVA_OPTS: "-Xms1g -Xmx1g"
   kibana:
     image: docker.elastic.co/kibana/kibana:5.5.2
+    container_name: kibana
     restart: always
     depends_on:
       - elasticsearch
@@ -236,6 +242,7 @@ services:
       discovery.type: "single-node"
   control-center:
     image: confluentinc/cp-enterprise-control-center:4.1.0
+    container_name: control-center
     restart: always
     depends_on:
       - zookeeper
@@ -270,6 +277,7 @@ services:
       CONTROL_CENTER_STREAMS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: "HTTPS"
   schemaregistry:
     image: confluentinc/cp-schema-registry:4.1.0
+    container_name: schemaregistry
     #restart: always
     depends_on:
       - zookeeper
@@ -304,6 +312,7 @@ services:
       - 8082:8082
   kafka-client:
     image: confluentinc/cp-enterprise-kafka:4.1.0
+    container_name: kafka-client
     depends_on:
       - kafka1
     hostname: kafka-client
@@ -344,6 +353,7 @@ services:
       - "7073:7073"
   ksql-cli:
     image: "confluentinc/ksql-cli:4.1.0"
+    container_name: ksql-cli
     depends_on:
       - kafka1
     ports:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -333,7 +333,7 @@ In this demo, KSQL is authenticated and authorized to connect to the secured Kaf
 
    .. sourcecode:: bash
 
-      $ docker exec cpdemo_connect_1 kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic EN_WIKIPEDIA_GT_1 \       
+      $ docker exec connect kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic EN_WIKIPEDIA_GT_1 \       
         --property schema.registry.url=https://schemaregistry:8082 \
         --consumer.config /etc/kafka/secrets/client_without_interceptors.config --max-messages 10
       null
@@ -345,7 +345,7 @@ In this demo, KSQL is authenticated and authorized to connect to the secured Kaf
       {"USERNAME":"Attar-Aram syria","WIKIPAGE":"Antiochus X Eusebes","COUNT":2}
       ...
 
-      $ docker exec cpdemo_connect_1 kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic EN_WIKIPEDIA_GT_1_COUNTS \
+      $ docker exec connect kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic EN_WIKIPEDIA_GT_1_COUNTS \
         --property schema.registry.url=https://schemaregistry:8082 \
         --consumer.config /etc/kafka/secrets/client_without_interceptors.config --max-messages 10
       {"USERNAME":"Atsme","COUNT":2,"WIKIPAGE":"Wikipedia:Articles for deletion/Metallurg Bratsk"}
@@ -1081,16 +1081,16 @@ Troubleshooting the demo
 
                  Name                        Command               State                              Ports
         ------------------------------------------------------------------------------------------------------------------------------
-        cpdemo_connect_1          /etc/confluent/docker/run        Up       0.0.0.0:8083->8083/tcp, 9092/tcp
-        cpdemo_control-center_1   /etc/confluent/docker/run        Up       0.0.0.0:9021->9021/tcp
-        cpdemo_elasticsearch_1    /bin/bash bin/es-docker          Up       0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp
-        cpdemo_kafka-client_1     bash -c -a echo Waiting fo ...   Exit 0
-        cpdemo_kafka1_1           /etc/confluent/docker/run        Up       0.0.0.0:29091->29091/tcp, 0.0.0.0:9091->9091/tcp, 9092/tcp
-        cpdemo_kafka2_1           /etc/confluent/docker/run        Up       0.0.0.0:29092->29092/tcp, 0.0.0.0:9092->9092/tcp
-        cpdemo_kibana_1           /bin/sh -c /usr/local/bin/ ...   Up       0.0.0.0:5601->5601/tcp
-        cpdemo_ksql-cli_1         perl -e while(1){ sleep 99 ...   Up       0.0.0.0:9098->9098/tcp
-        cpdemo_schemaregistry_1   /etc/confluent/docker/run        Up       8081/tcp, 0.0.0.0:8082->8082/tcp
-        cpdemo_zookeeper_1        /etc/confluent/docker/run        Up       0.0.0.0:2181->2181/tcp, 2888/tcp, 3888/tcp
+        connect                   /etc/confluent/docker/run        Up       0.0.0.0:8083->8083/tcp, 9092/tcp
+        control-center            /etc/confluent/docker/run        Up       0.0.0.0:9021->9021/tcp
+        elasticsearch             /bin/bash bin/es-docker          Up       0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp
+        kafka-client              bash -c -a echo Waiting fo ...   Exit 0
+        kafka1                    /etc/confluent/docker/run        Up       0.0.0.0:29091->29091/tcp, 0.0.0.0:9091->9091/tcp, 9092/tcp
+        kafka2                    /etc/confluent/docker/run        Up       0.0.0.0:29092->29092/tcp, 0.0.0.0:9092->9092/tcp
+        kibana                    /bin/sh -c /usr/local/bin/ ...   Up       0.0.0.0:5601->5601/tcp
+        ksql-cli                  perl -e while(1){ sleep 99 ...   Up       0.0.0.0:9098->9098/tcp
+        schemaregistry            /etc/confluent/docker/run        Up       8081/tcp, 0.0.0.0:8082->8082/tcp
+        zookeeper                 /etc/confluent/docker/run        Up       0.0.0.0:2181->2181/tcp, 2888/tcp, 3888/tcp
 
 2. To view sample messages for each topic, including
    ``wikipedia.parsed``:

--- a/scripts/app/start_consumer_app.sh
+++ b/scripts/app/start_consumer_app.sh
@@ -8,7 +8,7 @@ fi
 
 ID=$1
 
-docker exec cpdemo_connect_1 kafka-avro-console-consumer \
+docker exec connect kafka-avro-console-consumer \
    --bootstrap-server kafka1:9091 --topic wikipedia.parsed \
    --property schema.registry.url=https://schemaregistry:8082 \
    --consumer-property group.id=app --consumer-property client.id=consumer_app_$ID \

--- a/scripts/app/stop_consumer_app_group_graceful.sh
+++ b/scripts/app/stop_consumer_app_group_graceful.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker exec cpdemo_connect_1 ps aux | grep consumer_app | grep -v "grep" | awk '{print $2}' | xargs docker exec cpdemo_connect_1 kill -15
-ps aux | grep "docker exec cpdemo_connect_1" | grep -v "grep" | awk '{print $2}' | xargs kill -15
+docker exec connect ps aux | grep consumer_app | grep -v "grep" | awk '{print $2}' | xargs docker exec connect kill -15
+ps aux | grep "docker exec connect" | grep -v "grep" | awk '{print $2}' | xargs kill -15

--- a/scripts/app/stop_consumer_app_group_ungraceful.sh
+++ b/scripts/app/stop_consumer_app_group_ungraceful.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker exec cpdemo_connect_1 ps aux | grep consumer_app | grep -v "grep" | awk '{print $2}' | xargs docker exec cpdemo_connect_1 kill -9
-ps aux | grep "docker exec cpdemo_connect_1" | grep -v "grep" | awk '{print $2}' | xargs kill -9
+docker exec connect ps aux | grep consumer_app | grep -v "grep" | awk '{print $2}' | xargs docker exec connect kill -9
+ps aux | grep "docker exec connect" | grep -v "grep" | awk '{print $2}' | xargs kill -9

--- a/scripts/consumers/listen.sh
+++ b/scripts/consumers/listen.sh
@@ -3,26 +3,26 @@
 echo -e "Sample message from different topics:"
 
 echo -e "\nwikipedia.parsed:"
-docker exec cpdemo_connect_1 kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic wikipedia.parsed \
+docker exec connect kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic wikipedia.parsed \
   --property schema.registry.url=https://schemaregistry:8082 \
   --consumer.config /etc/kafka/secrets/client_without_interceptors.config --max-messages 1
 
 echo -e "\nwikipedia.parsed.replica:"
-docker exec cpdemo_connect_1 kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic wikipedia.parsed.replica \
+docker exec connect kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic wikipedia.parsed.replica \
   --property schema.registry.url=https://schemaregistry:8082 \
   --consumer.config /etc/kafka/secrets/client_without_interceptors.config --max-messages 1
   
 echo -e "\nWIKIPEDIABOT:"
-docker exec cpdemo_connect_1 kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic WIKIPEDIABOT \
+docker exec connect kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic WIKIPEDIABOT \
   --property schema.registry.url=https://schemaregistry:8082 \
   --consumer.config /etc/kafka/secrets/client_without_interceptors.config --max-messages 1
   
 echo -e "\nWIKIPEDIANOBOT:"
-docker exec cpdemo_connect_1 kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic WIKIPEDIANOBOT \
+docker exec connect kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic WIKIPEDIANOBOT \
   --property schema.registry.url=https://schemaregistry:8082 \
   --consumer.config /etc/kafka/secrets/client_without_interceptors.config --max-messages 1
 
 echo -e "\nEN_WIKIPEDIA_GT_1_COUNTS:"
-docker exec cpdemo_connect_1 kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic EN_WIKIPEDIA_GT_1_COUNTS \
+docker exec connect kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic EN_WIKIPEDIA_GT_1_COUNTS \
   --property schema.registry.url=https://schemaregistry:8082 \
   --consumer.config /etc/kafka/secrets/client_without_interceptors.config --max-messages 1

--- a/scripts/consumers/listen_EN_WIKIPEDIA_GT_1_COUNTS.sh
+++ b/scripts/consumers/listen_EN_WIKIPEDIA_GT_1_COUNTS.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker exec cpdemo_connect_1 kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic EN_WIKIPEDIA_GT_1_COUNTS \
+docker exec connect kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic EN_WIKIPEDIA_GT_1_COUNTS \
   --property schema.registry.url=https://schemaregistry:8082 \
   --consumer-property group.id=EN_WIKIPEDIA_GT_1_COUNTS-consumer \
   --consumer.config /etc/kafka/secrets/client_with_interceptors.config > /dev/null 2>&1 &

--- a/scripts/consumers/listen_WIKIPEDIANOBOT.sh
+++ b/scripts/consumers/listen_WIKIPEDIANOBOT.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker exec cpdemo_connect_1 kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic WIKIPEDIANOBOT \
+docker exec connect kafka-avro-console-consumer --bootstrap-server kafka1:9091 --topic WIKIPEDIANOBOT \
   --property schema.registry.url=https://schemaregistry:8082 \
   --consumer-property group.id=WIKIPEDIANOBOT-consumer \
   --consumer.config /etc/kafka/secrets/client_with_interceptors.config > /dev/null 2>&1 &

--- a/scripts/consumers/listen_wikipedia.failed.sh
+++ b/scripts/consumers/listen_wikipedia.failed.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker exec cpdemo_connect_1 kafka-avro-console-consumer \
+docker exec connect kafka-avro-console-consumer \
   --property schema.registry.url=https://schemaregistry:8082 \
   --bootstrap-server kafka1:9091 --topic wikipedia.failed \
   --consumer.config /etc/kafka/secrets/client_without_interceptors.config

--- a/scripts/consumers/listen_wikipedia.parsed.sh
+++ b/scripts/consumers/listen_wikipedia.parsed.sh
@@ -5,6 +5,6 @@ if [[ ! -z "$1" && "$1" == "SSL" ]]; then
   ARGS="--bootstrap-server kafka1:11091 --consumer.config /etc/kafka/secrets/client_without_interceptors_ssl.config"
 fi
 
-docker exec cpdemo_connect_1 kafka-avro-console-consumer \
+docker exec connect kafka-avro-console-consumer \
   --property schema.registry.url=https://schemaregistry:8082 \
   --topic wikipedia.parsed --group=test $ARGS

--- a/scripts/ksql/run_ksql.sh
+++ b/scripts/ksql/run_ksql.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-docker exec cpdemo_ksql-cli_1 ksql-server-start /tmp/ksqlproperties 2>&1 &
+docker exec ksql-cli ksql-server-start /tmp/ksqlproperties 2>&1 &
 sleep 10
-docker exec cpdemo_ksql-cli_1 bash -c "ksql http://localhost:8088 <<EOF
+docker exec ksql-cli bash -c "ksql http://localhost:8088 <<EOF
 run script '/tmp/ksqlcommands';
 exit ;
 EOF

--- a/scripts/ksql/run_ksql.sh
+++ b/scripts/ksql/run_ksql.sh
@@ -2,7 +2,8 @@
 
 docker exec cpdemo_ksql-cli_1 ksql-server-start /tmp/ksqlproperties 2>&1 &
 sleep 10
-docker-compose exec -T ksql-cli ksql http://localhost:8088 <<EOF
+docker exec cpdemo_ksql-cli_1 bash -c "ksql http://localhost:8088 <<EOF
 run script '/tmp/ksqlcommands';
 exit ;
 EOF
+"


### PR DESCRIPTION
This PR will fix two things:

Executing the run script in the KSQL server (was a problem for linux, not mac os)

Namespacing and how containers are called; no longer auto-generated but rather pre-defined in the docker-compose file using `container_name`. This change was required for compatibility with docker-compose v 1.21.0 released 13 days ago