### PR TITLE
Fix linux

### DIFF
--- a/scripts/ksql/run_ksql.sh
+++ b/scripts/ksql/run_ksql.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-docker exec cpdemo_ksql-cli_1 ksql-server-start /tmp/ksqlproperties 2>&1 &
+KSQL_CONTAINER_NAME=$(docker-compose ps | grep ksql-cli | awk '{print $1}')
+
+docker exec ${KSQL_CONTAINER_NAME} ksql-server-start /tmp/ksqlproperties 2>&1 &
 sleep 10
-docker exec cpdemo_ksql-cli_1 bash -c "ksql http://localhost:8088 <<EOF
+docker exec ${KSQL_CONTAINER_NAME} bash -c "ksql http://localhost:8088 <<EOF
 run script '/tmp/ksqlcommands';
 exit ;
 EOF

--- a/scripts/ksql/run_ksql.sh
+++ b/scripts/ksql/run_ksql.sh
@@ -2,7 +2,8 @@
 
 docker exec cpdemo_ksql-cli_1 ksql-server-start /tmp/ksqlproperties 2>&1 &
 sleep 10
-docker-compose exec -T ksql-cli ksql http://localhost:8088 <<EOF
+docker exec cpdemo_ksql-cli_1 bash -c "ksql http://localhost:8088 <<EOF
 run script '/tmp/ksqlcommands';
 exit ;
 EOF
+"


### PR DESCRIPTION
This will look up the name of the container instead of relying on a static name for `run_ksql.sh` as it seems like different versions of docker name the containers differently.