### PR TITLE
Use C3 URL that goes to 30 min view directly

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,7 +80,7 @@ Run demo
 
       $ ./scripts/start.sh
 
-4. Use Google Chrome to view the |c3| GUI at http://localhost:9021. Click on the top right button that shows the current date, and change ``Last 4 hours`` to ``Last 30 minutes``.
+4. Use Google Chrome to view the `|c3| GUI <http://localhost:9021/monitoring/system/brokers?latencyPercentile=95&rolling=30&view=RAW>`_.
 
 5. View the data in the Kibana dashboard at http://localhost:5601/app/kibana#/dashboard/Wikipedia
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -107,3 +107,6 @@ echo -e "\nWaiting for everything to stabilize, sleeping 30 seconds"
 sleep 30
 
 echo -e "\nDONE! Connect to Confluent Control Center at http://localhost:9021\n"
+if [[ $(uname -s) == "Darwin" ]]; then
+  open "http://localhost:9021/monitoring/system/brokers?latencyPercentile=95&rolling=30&view=RAW"
+fi


### PR DESCRIPTION
Small tweak to URL to save the manual step of needing to change the time window

On Mac, will also open it directly after everything's started up