### PR TITLE
DEVX-658, DEVX-657:

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -507,6 +507,8 @@ services:
     ports:
       - 8086:8086
 
+  # This container is just to transfer Replicator jars to the Connect worker
+  # It is not used as a Connect worker
   replicator:
     image: confluentinc/cp-enterprise-replicator:5.1.0
     hostname: replicator
@@ -516,7 +518,7 @@ services:
     environment:
       CONNECT_BOOTSTRAP_SERVERS: localhost:8882
       CONNECT_REST_PORT: 8883
-      CONNECT_GROUP_ID: "connect-replicator"
+      CONNECT_GROUP_ID: "connect-bogus"
       CONNECT_CONFIG_STORAGE_TOPIC: "default.config"
       CONNECT_OFFSET_STORAGE_TOPIC: "default.offsets"
       CONNECT_STATUS_STORAGE_TOPIC: "default.status"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -509,26 +509,13 @@ services:
 
   # This container is just to transfer Replicator jars to the Connect worker
   # It is not used as a Connect worker
-  replicator:
+  replicator-for-jar-transfer:
     image: confluentinc/cp-enterprise-replicator:5.1.0
-    hostname: replicator
-    container_name: replicator
+    hostname: replicator-for-jar-transfer
+    container_name: replicator-for-jar-transfer
     volumes:
       - mi3:/usr/share/java/kafka-connect-replicator/
-    environment:
-      CONNECT_BOOTSTRAP_SERVERS: localhost:8882
-      CONNECT_REST_PORT: 8883
-      CONNECT_GROUP_ID: "connect-bogus"
-      CONNECT_CONFIG_STORAGE_TOPIC: "default.config"
-      CONNECT_OFFSET_STORAGE_TOPIC: "default.offsets"
-      CONNECT_STATUS_STORAGE_TOPIC: "default.status"
-      CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
-      CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
-      CONNECT_INTERNAL_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
-      CONNECT_INTERNAL_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
-      CONNECT_REST_ADVERTISED_HOST_NAME: "localhost"
-      CONNECT_LOG4J_ROOT_LOGLEVEL: DEBUG
-    command: "tail -f /dev/null"
+    command: "sleep infinity"
 
 volumes:
     mi3: {}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1115,21 +1115,21 @@ Troubleshooting the demo
 
    .. sourcecode:: bash
 
-                 Name                        Command               State                              Ports
-        ------------------------------------------------------------------------------------------------------------------------------
-        connect          /etc/confluent/docker/run                 Up      0.0.0.0:8083->8083/tcp, 9092/tcp                          
-        control-center   /etc/confluent/docker/run                 Up      0.0.0.0:9021->9021/tcp, 0.0.0.0:9022->9022/tcp
-        elasticsearch    /bin/bash bin/es-docker                   Up      0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp            
-        kafka-client     bash -c -a echo Waiting fo ...            Exit 0
-        kafka1           /etc/confluent/docker/run                 Up      0.0.0.0:29091->29091/tcp, 0.0.0.0:9091->9091/tcp, 9092/tcp
-        kafka2           /etc/confluent/docker/run                 Up      0.0.0.0:29092->29092/tcp, 0.0.0.0:9092->9092/tcp          
-        kibana           /bin/sh -c /usr/local/bin/ ...            Up      0.0.0.0:5601->5601/tcp                                    
-        ksql-cli         /bin/sh                                   Up                                                                
-        ksql-server      /etc/confluent/docker/run                 Up      0.0.0.0:8088->8088/tcp                                    
-        replicator       tail -f /dev/null                         Up      8083/tcp, 9092/tcp                                        
-        restproxy        /etc/confluent/docker/run                 Up      8082/tcp, 0.0.0.0:8086->8086/tcp                          
-        schemaregistry   /etc/confluent/docker/run                 Up      8081/tcp, 0.0.0.0:8085->8085/tcp                          
-        zookeeper        /etc/confluent/docker/run                 Up      0.0.0.0:2181->2181/tcp, 2888/tcp, 3888/tcp   
+                   Name                          Command               State                             Ports                           
+        ---------------------------------------------------------------------------------------------------------------------------------
+        connect                       /etc/confluent/docker/run        Up      0.0.0.0:8083->8083/tcp, 9092/tcp                          
+        control-center                /etc/confluent/docker/run        Up      0.0.0.0:9021->9021/tcp, 0.0.0.0:9022->9022/tcp            
+        elasticsearch                 /bin/bash bin/es-docker          Up      0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp            
+        kafka-client                  bash -c -a echo Waiting fo ...   Up      0.0.0.0:7073->7073/tcp, 9092/tcp                          
+        kafka1                        /etc/confluent/docker/run        Up      0.0.0.0:29091->29091/tcp, 0.0.0.0:9091->9091/tcp, 9092/tcp
+        kafka2                        /etc/confluent/docker/run        Up      0.0.0.0:29092->29092/tcp, 0.0.0.0:9092->9092/tcp          
+        kibana                        /bin/sh -c /usr/local/bin/ ...   Up      0.0.0.0:5601->5601/tcp                                    
+        ksql-cli                      /bin/sh                          Up                                                                
+        ksql-server                   /etc/confluent/docker/run        Up      0.0.0.0:8088->8088/tcp                                    
+        replicator-for-jar-transfer   sleep infinity                   Up      8083/tcp, 9092/tcp                                        
+        restproxy                     /etc/confluent/docker/run        Up      8082/tcp, 0.0.0.0:8086->8086/tcp                          
+        schemaregistry                /etc/confluent/docker/run        Up      8081/tcp, 0.0.0.0:8085->8085/tcp                          
+        zookeeper                     /etc/confluent/docker/run        Up      0.0.0.0:2181->2181/tcp, 2888/tcp, 3888/tcp    
 
 2. To view sample messages for each topic, including
    ``wikipedia.parsed``:

--- a/scripts/connectors/submit_replicator_config.sh
+++ b/scripts/connectors/submit_replicator_config.sh
@@ -50,6 +50,7 @@ DATA=$( cat << EOF
     "src.kafka.timestamps.producer.confluent.monitoring.interceptor.ssl.keystore.password": "confluent",
     "src.kafka.timestamps.producer.confluent.monitoring.interceptor.sasl.jaas.config": "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"client\" password=\"client-secret\";",
     "src.kafka.timestamps.producer.confluent.monitoring.interceptor.sasl.mechanism": "PLAIN",
+    "offset.timestamps.commit": "false",
     "tasks.max": "1"
   }
 }


### PR DESCRIPTION
1. DEVX-658: disable offset.timestamps.commit in Replicator so that wikipedia.parsed.replica does not show up in Control Center consumer lag (relevant when Replicator consumer lag shows in C3 in 5.1.1)
2. DEVX-657: do not overload `connect-replicator`, add comment to Docker compose
