### PR TITLE
Add keytool to the list of commands to verify are installed

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -16,6 +16,7 @@ verify_installed()
 }
 verify_installed "jq"
 verify_installed "docker-compose"
+verify_installed "keytool"
 
 # Verify Docker memory is increased to at least 8GB
 DOCKER_MEMORY=$(docker system info | grep Memory | grep -o "[0-9\.]\+")


### PR DESCRIPTION
Add verification that the `keytool` command is installed. If it isn't installed the certificates won't get created, but docker-compose still runs (and fails).