### PR TITLE
Add "keytool" to the list of applications that get verified

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -16,6 +16,7 @@ verify_installed()
 }
 verify_installed "jq"
 verify_installed "docker-compose"
+verify_installed "keytool"
 
 # Verify Docker memory is increased to at least 8GB
 DOCKER_MEMORY=$(docker system info | grep Memory | grep -o "[0-9\.]\+")


### PR DESCRIPTION
If `keytool` isn't installed, `docker-compose up` still runs, but the certificates never got created, so Kafka fails to start.