### PR TITLE
DEVX-878: 'SASL_SSL://' no longer required in schema registry config …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -321,7 +321,7 @@ services:
     volumes:
       - $PWD/scripts/security:/etc/kafka/secrets
     environment:
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "SASL_SSL://kafka1:9091,SASL_SSL://kafka2:9092"
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "kafka1:9091,kafka2:9092"
       SCHEMA_REGISTRY_HOST_NAME: schemaregistry
       SCHEMA_REGISTRY_LISTENERS: "https://0.0.0.0:8085"
       SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL: SASL_SSL


### PR DESCRIPTION
…parameter value for kafkastore.bootstrap.servers