### PR TITLE
remove eof warnings

### DIFF
--- a/scripts/dashboard/set_elasticsearch_mapping_bot.sh
+++ b/scripts/dashboard/set_elasticsearch_mapping_bot.sh
@@ -43,8 +43,8 @@ DATA=$( cat << EOF
         }
     }
 }
-
-EOF);
+EOF
+)
 
 curl -XPUT -H "${HEADER}" --data "${DATA}" 'http://localhost:9200/wikipediabot?pretty'
 echo

--- a/scripts/dashboard/set_elasticsearch_mapping_count.sh
+++ b/scripts/dashboard/set_elasticsearch_mapping_count.sh
@@ -28,8 +28,8 @@ DATA=$( cat << EOF
         }
     }
 }
-
-EOF);
+EOF
+)
 
 curl -XPUT -H "${HEADER}" --data "${DATA}" 'http://localhost:9200/en_wikipedia_gt_1?pretty'
 echo


### PR DESCRIPTION
Having the EOF formatted as
```EOF);```
instead of
```
EOF
)
```
causes the following warning:
``warning: here-document at line 50 delimited by end-of-file (wanted `EOF').``
By removing the semi-colon and adding a LF between the EOF and the ), the warning goes away.