### PR TITLE
 Add env discovery.type: "single-node" to elasticsearch service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,6 +240,7 @@ services:
       - "9300:9300"
     environment:
       xpack.security.enabled: "false"
+      discovery.type: "single-node"
       ES_JAVA_OPTS: "-Xms1g -Xmx1g"
   kibana:
     image: docker.elastic.co/kibana/kibana:5.5.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,7 +252,6 @@ services:
       - "5601:5601"
     environment:
       xpack.security.enabled: "false"
-      discovery.type: "single-node"
   control-center:
     image: confluentinc/cp-enterprise-control-center:5.3.0
     container_name: control-center


### PR DESCRIPTION
Moves env `discovery.type: "single-node"` from `kibana` service where it is unneeded, to `elasticsearch` service.

To test current problem, on a standard AWS EC2 machine with Docker and Compose, try and bring-up the `elasticsearch` service with `docker-compose up -d --no-deps elasticsearch`.  Provided Docker Compose creates a network that Elastic determines is non-local and could be a production deployment (_bound or publishing to a non-loopback or non-link-local address, enforcing bootstrap checks_) it will run its bootstrap checks, which could fail e.g.:

```
elasticsearch                  | [2019-08-18T10:37:05,699][INFO ][o.e.d.DiscoveryModule    ] [pRtsMlB] using discovery type [zen]
elasticsearch                  | [2019-08-18T10:37:10,203][INFO ][o.e.n.Node               ] initialized
elasticsearch                  | [2019-08-18T10:37:10,203][INFO ][o.e.n.Node               ] [pRtsMlB] starting ...
elasticsearch                  | [2019-08-18T10:37:11,206][INFO ][o.e.t.TransportService   ] [pRtsMlB] publish_address {172.23.0.2:9300}, bound_addresses {0.0.0.0:9300}
elasticsearch                  | [2019-08-18T10:37:11,217][INFO ][o.e.b.BootstrapChecks    ] [pRtsMlB] bound or publishing to a non-loopback or non-link-local address, enforcing bootstrap checks
elasticsearch                  | ERROR: [1] bootstrap checks failed
elasticsearch                  | [1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]
elasticsearch                  | [2019-08-18T10:37:11,298][INFO ][o.e.n.Node               ] [pRtsMlB] stopping ...
elasticsearch                  | [2019-08-18T10:37:11,415][INFO ][o.e.n.Node               ] [pRtsMlB] stopped
elasticsearch                  | [2019-08-18T10:37:11,416][INFO ][o.e.n.Node               ] [pRtsMlB] closing ...
elasticsearch                  | [2019-08-18T10:37:11,500][INFO ][o.e.n.Node               ] [pRtsMlB] closed
elasticsearch                  | [2019-08-18T10:37:11,507][INFO ][o.e.x.m.j.p.NativeController] Native controller process has stopped - no new native processes can be started
elasticsearch exited with code 78
```

With this env set, it should succeed with:

```
elasticsearch                  | [2019-08-18T10:38:33,207][INFO ][o.e.d.DiscoveryModule    ] [KXEM6Wn] using discovery type [single-node]
elasticsearch                  | [2019-08-18T10:38:38,301][INFO ][o.e.n.Node               ] initialized
elasticsearch                  | [2019-08-18T10:38:38,301][INFO ][o.e.n.Node               ] [KXEM6Wn] starting ...
```

Fixes #11, fixes #114 .
