### PR TITLE
DEVX-1166 only removes our docker volumes, and simplifies ksql-server-start shutdown call

### DIFF
--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-pkill ksql-server-start
-
 docker-compose down --volumes
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-ps aux | grep ksql-server-start | grep -v "grep ksql" | awk '{print $2}' | xargs kill -15
+pkill ksql-server-start
 
-docker-compose down
+docker-compose down --volumes
 
-for v in $(docker volume ls -q --filter="dangling=true"); do
-	docker volume rm "$v"
-done


### PR DESCRIPTION
Uses docker-compose to remove our volumes instead of ones outside our compose project.  

Verified cleanup with the following before, during and after running cp-demo:
```
[I] ➜ docker volume ls
DRIVER              VOLUME NAME

cp-demo/scripts on  DEVX-1166 [!]
[I] ➜ docker volume ls
DRIVER              VOLUME NAME
local               1ec4827957cfa0e71a3ab99912c193a78c30f2497b84b26cafa53a75b0336747
local               3daf7c9a15cdf925398bc1c62e3e2091d266c5012e11ac2fcc6c7450795781a3
local               4e7701e17b89d27fc77fb17d55253508e70bbc309284de774a067da962a9801a
local               8a0b6334748589a7c4199de34163b5ba158cf53b0d53343c5da4021ac7e3a4be
local               8d450c9ddddef417ec33b8194557f46cb9d00aeb0418d8d29d706e4e1c98717a
local               45a801ad17f2c925992260960ba364f3f9c8e1d35ec6c61f77e3aa44368dda82
local               626db9fb68f59082f0af2ccdf1067c3d0d567fad6f2b21461fb5565a19ef4ef8
local               752a43eef49fe31f21b38753d182ad1f5fbcc75d620378df419770b9ea0254d1
local               0436260f74177b9e44899da0f715574633206acb7717d2538c39c3a788a10cf6
local               8092621969b06245255c7f8103ae5681ce2dcea91c3e132bf038599a36676f65
local               b40241c0d019ae0f681c2d4d113964c84d67d198a5412b49d0a0edf43109c69e
local               bad5e4790a9e453f851e9651cc1417be069b3a3b4d344c460d569d7bef559524
local               cp-demo_mi3
local               d97d3a86f6cc7138dee660a9bbd5c040014c7a1983d7dc615ffd978f9489f948
local               e562bcaa742a49433f5f3efb73c8b7103482c23e641afbcb7c51b56e28eaa5ff
local               f7c4f9e4cfaef85ca43dbae82fe58c5fb1cd84f346fe937010449896ba44c207

cp-demo/scripts on  DEVX-1166 [!]
[I] ➜ docker volume ls
DRIVER              VOLUME NAME
```

Also used `pkill` to kill a lingering ksql-server-start process instead of complex search and kill command.  Verified pkill is available on osx, centos, and ubuntu