### PR TITLE
cp-demo: Bump 5.4.x branch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
       CONNECT_PLUGIN_PATH: "/usr/share/java,/connect-plugins"
       CONNECT_LOG4J_ROOT_LOGLEVEL: INFO
       CONNECT_LOG4J_LOGGERS: org.reflections=ERROR
-      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-5.4.x-latest.jar
+      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-5.4.0-SNAPSHOT.jar
       # Connect worker
       CONNECT_SECURITY_PROTOCOL: SASL_SSL
       CONNECT_SASL_JAAS_CONFIG: "org.apache.kafka.common.security.plain.PlainLoginModule required \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     restart: always
     hostname: zookeeper
     container_name: zookeeper
@@ -18,7 +18,7 @@ services:
       - "2181:2181"
 
   kafka1:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: kafka1
     container_name: kafka1
     cpus: 0.7
@@ -80,7 +80,7 @@ services:
                   -Djavax.net.ssl.keyStore=/etc/kafka/secrets/kafka.kafka1.keystore.jks
                   -Djavax.net.ssl.keyStorePassword=confluent
   kafka2:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: kafka2
     container_name: kafka2
     cpus: 0.7
@@ -142,7 +142,7 @@ services:
                   -Djavax.net.ssl.keyStore=/etc/kafka/secrets/kafka.kafka2.keystore.jks
                   -Djavax.net.ssl.keyStorePassword=confluent
   connect:
-    image: confluentinc/cp-server-connect:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server-connect:5.4.x-latest
     container_name: connect
     cpus: 0.6
     restart: always
@@ -180,7 +180,7 @@ services:
       CONNECT_PLUGIN_PATH: "/usr/share/java,/connect-plugins"
       CONNECT_LOG4J_ROOT_LOGLEVEL: INFO
       CONNECT_LOG4J_LOGGERS: org.reflections=ERROR
-      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-5.4.0-SNAPSHOT.jar
+      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-5.4.x-latest.jar
       # Connect worker
       CONNECT_SECURITY_PROTOCOL: SASL_SSL
       CONNECT_SASL_JAAS_CONFIG: "org.apache.kafka.common.security.plain.PlainLoginModule required \
@@ -261,7 +261,7 @@ services:
     environment:
       xpack.security.enabled: "false"
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-control-center:5.4.x-latest
     container_name: control-center
     cpus: 0.7
     restart: always
@@ -318,7 +318,7 @@ services:
       CONTROL_CENTER_REST_SSL_KEYSTORE_PASSWORD: confluent
       CONTROL_CENTER_REST_SSL_KEY_PASSWORD: confluent
   schemaregistry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     container_name: schemaregistry
     cpus: 0.4
     restart: always
@@ -354,7 +354,7 @@ services:
     ports:
       - 8085:8085
   kafka-client:
-    image: confluentinc/cp-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-server:5.4.x-latest
     hostname: kafka-client
     container_name: kafka-client
     cpus: 0.4
@@ -403,7 +403,7 @@ services:
       - "7073:7073"
 
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-server:5.4.x-latest
     hostname: ksql-server
     container_name: ksql-server
     cpus: 0.5
@@ -476,7 +476,7 @@ services:
       KSQL_KSQL_SERVER_UI_ENABLED: "false"
 
   ksql-cli:
-    image: confluentinc/cp-ksql-cli:5.4.0-SNAPSHOT
+    image: confluentinc/cp-ksql-cli:5.4.x-latest
     container_name: ksql-cli
     cpus: 0.4
     depends_on:
@@ -488,7 +488,7 @@ services:
     entrypoint: /bin/sh
     tty: true
   restproxy:
-    image: confluentinc/cp-kafka-rest:5.4.0-SNAPSHOT
+    image: confluentinc/cp-kafka-rest:5.4.x-latest
     restart: always
     cpus: 0.4
     depends_on:
@@ -532,7 +532,7 @@ services:
   # This container is just to transfer Replicator jars to the Connect worker
   # It is not used as a Connect worker
   replicator-for-jar-transfer:
-    image: confluentinc/cp-enterprise-replicator:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-replicator:5.4.x-latest
     hostname: replicator-for-jar-transfer
     container_name: replicator-for-jar-transfer
     volumes:


### PR DESCRIPTION
cp-demo: Bump 5.4.x branch

Issue:
Docker image tag got bumped to in-correct value for docker image tags.

- learn about all the changes required for devx repositories both during branch cut & release version bumps.
- address immediate issue by bumping these to 5.4.x-latest
- update branch cut steps to avoid future issues:
https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/582517464/Major+Minor+Release+Release+Branch+Creation+Feature+Freeze#Major/MinorRelease:ReleaseBranchCreation(FeatureFreeze)-DevXFollowups

Automate via tooling - Added jira to fix tooling:
https://confluentinc.atlassian.net/browse/ST-2650