### PR TITLE
ST-2811: Making the connection check to wikimedia irc work on rhel

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -74,10 +74,10 @@ while [[ ! $(docker-compose logs connect) =~ "Herder started" ]]; do
   fi
 done
 
-if [[ ! $(docker-compose exec connect timeout 3 nc -zv irc.wikimedia.org 6667) =~ "open" ]]; then
+docker-compose exec connect timeout 3 nc -zv irc.wikimedia.org 6667 || {
   echo -e "\nERROR: irc.wikimedia.org 6667 is unreachable. Please ensure connectivity before proceeding or try setting 'irc.server.port' to 8001 in scripts/connectors/submit_wikipedia_irc_config.sh\n"
   exit 1
-fi
+}
 
 echo -e "\nStart streaming from the IRC source connector:"
 ${DIR}/connectors/submit_wikipedia_irc_config.sh


### PR DESCRIPTION
On RHEL images the nc command output is formatted differently and does not contain the word we currently search for in order to determine success. I did test that this command will return a non-zero error code if it fails, so there is no need to parse the output. This will continue to work on Debian and RHEL images.