### PR TITLE
ST-2811: Fix curl connection issue with rhel images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,6 +245,7 @@ services:
                   -Djavax.net.ssl.trustStorePassword=confluent
                   -Djavax.net.ssl.keyStore=/etc/kafka/secrets/kafka.connect.keystore.jks
                   -Djavax.net.ssl.keyStorePassword=confluent
+      CONNECT_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.0
     container_name: elasticsearch
@@ -326,6 +327,7 @@ services:
       CONTROL_CENTER_REST_SSL_KEYSTORE_LOCATION: /etc/kafka/secrets/kafka.control-center.keystore.jks
       CONTROL_CENTER_REST_SSL_KEYSTORE_PASSWORD: confluent
       CONTROL_CENTER_REST_SSL_KEY_PASSWORD: confluent
+      CONTROL_CENTER_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
   schemaregistry:
     image: confluentinc/cp-schema-registry:5.4.x-latest
     container_name: schemaregistry
@@ -360,6 +362,7 @@ services:
       SCHEMA_REGISTRY_SSL_CLIENT_AUTH: "true"
       SCHEMA_REGISTRY_SCHEMA_REGISTRY_INTER_INSTANCE_PROTOCOL: "https"
       SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL: INFO
+      SCHEMA_REGISTRY_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
     ports:
       - 8085:8085
   kafka-client:
@@ -536,6 +539,7 @@ services:
       KAFKA_REST_CLIENT_SASL_JAAS_CONFIG: "org.apache.kafka.common.security.plain.PlainLoginModule required \
               username=\"client\" \
               password=\"client-secret\";"
+      KAFKA_REST_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
     ports:
       - 8086:8086
 


### PR DESCRIPTION
The curl commands were failing with the rhel images because the key was not strong enough. This is the error:
curl: (35) error:141A318A:SSL routines:tls_process_ske_dhe:dh key too small

This change will resolve that issue so that cp-demo can work with our new rhel ubi images when making curl commands. 

I tested this by running cp-demo using rhel and debian images.