### PR TITLE
ST-2811: Make map topics clients script work with python3

### DIFF
--- a/scripts/app/map_topics_clients.py
+++ b/scripts/app/map_topics_clients.py
@@ -89,7 +89,7 @@ def get_output():
     print("Reading topic _confluent-monitoring for 60 seconds...please wait")
 
     try:
-        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        proc = subprocess.Popen(command, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     except Exception as e:
         print(e)
 


### PR DESCRIPTION
When running this script using Python3 the subprocess command will return the data in bytes, where as in python2 it returned a unicode string. This causes the call to split each line fail. This change will make it so the call returns unicode. I tested this using Python3.6 and Python2.7