### PR TITLE
Changed verify_installed Bash function

### DIFF
--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -34,7 +34,7 @@ verify_installed()
 preflight_checks()
 {
   # Verify appropriate tools are installed on host
-  for cmd in jq docker-compose keytool docker openssl python; do
+  for cmd in jq docker-compose keytool docker openssl python3 do
     verify_installed $cmd || exit 1
   done
 


### PR DESCRIPTION
Changed verify_installed Bash function to reference python3 executable. On most default installations python is python version 2.