### PR TITLE
DEVX-1729: Reduce Connect's memory utilization through GC reconfiguration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -499,6 +499,14 @@ services:
                   -Djavax.net.ssl.keyStore=/etc/kafka/secrets/kafka.connect.keystore.jks
                   -Djavax.net.ssl.keyStorePassword=confluent
       CONNECT_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+
+      # Reduce Connect memory utilization
+      KAFKA_JVM_PERFORMANCE_OPTS: -server -XX:+UseG1GC -XX:GCTimeRatio=1
+                  -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20
+                  -XX:MaxGCPauseMillis=10000 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent
+                  -XX:MaxInlineLevel=15 -Djava.awt.headless=true
+
+
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.0
     container_name: elasticsearch


### PR DESCRIPTION
Before:

```
connect             67576369569e        6.15%               1.908GiB / 7.778GiB
```

After:

```
connect             962e93b24c9f        14.60%              711.2MiB / 7.778GiB
```