### PR TITLE
Bump KStreams Demo version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -890,7 +890,7 @@ services:
     command: "sleep infinity"
 
   streams-demo:
-    image: cnfldemos/cp-demo-kstreams:0.0.5
+    image: cnfldemos/cp-demo-kstreams:0.0.6
     restart: always
     cpus: 0.4
     depends_on:


### PR DESCRIPTION
Current KStreams version was using versions cp-5.4.0/kafka-2.4.0. New image is available :)

New image: <https://hub.docker.com/layers/cnfldemos/cp-demo-kstreams/0.0.6>

Ref: https://github.com/confluentinc/demos-common/pull/3
