### PR TITLE
Updated the training-tools container image to 5.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ./scripts/security:/etc/kafka/secrets
 
   tools:
-    image: cnfltraining/training-tools:5.4
+    image: cnfltraining/training-tools:5.5
     hostname: tools
     container_name: tools
     depends_on:


### PR DESCRIPTION
Note: this rev looks like it could be easily-missed since versions are externalised to `config.env` e.g. `CONFLUENT_DOCKER_TAG=5.5.0`.  I wondered if another variable could be added close-by, or even co-opt `CONFLUENT_SHORT=5.5` so that they would be updated together - thoughts?