### PR TITLE
DEVX-1794: Enable cp-demo start script to be run from scripts subfolder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,16 +3,16 @@
 
 .DS_Store
 *.idea
-scripts/security/*.crt
-scripts/security/*.csr
-scripts/security/*_creds
-scripts/security/*.jks
-scripts/security/*.srl
-scripts/security/*.key
-scripts/security/*.req
-scripts/security/*.pem
-scripts/security/*.der
-scripts/security/*.p12
-conf/
+**/*.crt
+**/*.csr
+**/*_creds
+**/*.jks
+**/*.srl
+**/*.key
+**/*.req
+**/*.pem
+**/*.der
+**/*.p12
+**/keypair/
 ui/expanded
 *.zip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - zookeeper
       - openldap
     volumes:
-      - ./conf:/tmp/conf
+      - ./scripts/security/keypair:/tmp/conf
       - ./scripts/helper:/tmp/helper
       - ./scripts/security:/etc/kafka/secrets
     command: "bash -c 'if [ ! -f /etc/kafka/secrets/kafka.kafka1.keystore.jks ]; then echo \"ERROR: Did not find SSL certificates in /etc/kafka/secrets/ (did you remember to run ./scripts/start.sh instead of docker-compose up -d?)\" && exit 1 ; else /etc/confluent/docker/run ; fi'"
@@ -214,7 +214,7 @@ services:
       - zookeeper
       - openldap
     volumes:
-      - ./conf:/tmp/conf
+      - ./scripts/security/keypair:/tmp/conf
       - ./scripts/helper:/tmp/helper
       - ./scripts/security:/etc/kafka/secrets
     command: "bash -c 'if [ ! -f /etc/kafka/secrets/kafka.kafka2.keystore.jks ]; then echo \"ERROR: Did not find SSL certificates in /etc/kafka/secrets/ (did you remember to run ./scripts/start.sh instead of docker-compose up -d?)\" && exit 1 ; else /etc/confluent/docker/run ; fi'"
@@ -359,7 +359,7 @@ services:
     volumes:
       - ./connect-plugins:/connect-plugins
       - ./scripts/security:/etc/kafka/secrets
-      - ./conf:/tmp/conf
+      - ./scripts/security/keypair:/tmp/conf
     ports:
       - 8083:8083
     environment:
@@ -558,7 +558,7 @@ services:
       - schemaregistry
       - connect
     volumes:
-      - ./conf:/tmp/conf
+      - ./scripts/security/keypair:/tmp/conf
       - ./scripts/security:/etc/kafka/secrets
     ports:
       - 9021:9021
@@ -641,7 +641,7 @@ services:
       - kafka2
     volumes:
       - ./scripts/security:/etc/kafka/secrets
-      - ./conf:/tmp/conf
+      - ./scripts/security/keypair:/tmp/conf
     ports:
       - 8085:8085
     environment:
@@ -755,7 +755,7 @@ services:
       - kafka2
       - connect
     volumes:
-      - ./conf:/tmp/conf
+      - ./scripts/security/keypair:/tmp/conf
       - ./scripts/helper:/tmp/helper
       - ./scripts/security:/etc/kafka/secrets
     ports:
@@ -871,7 +871,7 @@ services:
     volumes:
       - ./scripts/security:/etc/kafka/secrets
       - ./scripts/app:/etc/kafka/app
-      - ./conf:/tmp/conf
+      - ./scripts/security/keypair:/tmp/conf
     ports:
       - 8086:8086
     environment:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -16,9 +16,9 @@ echo -e "Generate keys and certificates used for SSL"
 
 # Generating public and private keys for token signing
 echo "Generating public and private keys for token signing"
-mkdir -p ./conf
-openssl genrsa -out ./conf/keypair.pem 2048
-openssl rsa -in ./conf/keypair.pem -outform PEM -pubout -out ./conf/public.pem
+mkdir -p ${DIR}/security/keypair
+openssl genrsa -out ${DIR}/security/keypair/keypair.pem 2048
+openssl rsa -in ${DIR}/security/keypair/keypair.pem -outform PEM -pubout -out ${DIR}/security/keypair/public.pem
 
 # Bring up openldap
 docker-compose up -d openldap

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -54,8 +54,8 @@ if [[ "${CONNECTOR_VERSION}" =~ "SNAPSHOT" ]]; then
     exit 1;
   }
 else
-  echo "docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f Dockerfile-confluenthub ."
-  docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f Dockerfile-confluenthub . || {
+  echo "docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f ${DIR}/../Dockerfile-confluenthub ."
+  docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f ${DIR}/../Dockerfile-confluenthub . || {
     echo "ERROR: Docker image build failed. Please troubleshoot and try again."
     exit 1;
   }


### PR DESCRIPTION
Fixes two problems:

MDS timeout (kafka broker never starts due to missing pem file) and this error:

```
Building custom Docker image with Connect version 5.5.0 and connector version 5.5.0
docker build --build-arg CP_VERSION=5.5.0 --build-arg CONNECTOR_VERSION=5.5.0 -t localbuild/connect:5.5.0-5.5.0 -f Dockerfile-confluenthub .
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /Users/yeva/git/cp-demo/scripts/Dockerfile-confluenthub: no such file or directory
ERROR: Docker image build failed. Please troubleshoot and try again.
```