### PR TITLE
[DEVX-1885] update cub classpath for UBI-based images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -361,7 +361,7 @@ services:
     ports:
       - 8083:8083
     environment:
-      CUB_CLASSPATH: '/etc/confluent/docker/docker-utils.jar:/usr/share/java/confluent-security/connect/*:/usr/share/java/kafka/*'
+      CUB_CLASSPATH: '/usr/share/java/cp-base-new/*:/usr/share/java/confluent-security/connect/*:/usr/share/java/kafka/*'
       CONNECT_BOOTSTRAP_SERVERS: kafka1:10091,kafka2:10092
       CONNECT_REST_PORT: 8083
       CONNECT_LISTENERS: https://0.0.0.0:8083
@@ -563,8 +563,7 @@ services:
       - 9022:9022
     environment:
       # CUB CLASSPATH
-      CUB_CLASSPATH: '/etc/confluent/docker/docker-utils.jar:/usr/share/java/confluent-control-center/*:/usr/share/java/rest-utils/*:/usr/share/java/confluent-common/*'
-      # CUB_CLASSPATH: '/etc/confluent/docker/docker-utils.jar:/usr/share/java/confluent-control-center/*'
+      CUB_CLASSPATH: '/usr/share/java/cp-base-new/*:/usr/share/java/confluent-control-center/*:/usr/share/java/rest-utils/*:/usr/share/java/confluent-common/*'
 
       # general settings
       CONTROL_CENTER_BOOTSTRAP_SERVERS: kafka1:10091,kafka2:10092
@@ -643,7 +642,7 @@ services:
     ports:
       - 8085:8085
     environment:
-      CUB_CLASSPATH: '/etc/confluent/docker/docker-utils.jar:/usr/share/java/confluent-security/schema-registry/*:/usr/share/java/schema-registry/*'
+      CUB_CLASSPATH: '/usr/share/java/cp-base-new/*:/usr/share/java/confluent-security/schema-registry/*:/usr/share/java/schema-registry/*'
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka1:10091,kafka2:10092
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181
       SCHEMA_REGISTRY_HOST_NAME: schemaregistry
@@ -898,7 +897,7 @@ services:
       KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper:2181
 
       # Credentials and classpath for cub kafka-ready
-      CUB_CLASSPATH: '/etc/confluent/docker/docker-utils.jar:/usr/share/java/confluent-security/kafka-rest/*:/usr/share/java/kafka-rest/*'
+      CUB_CLASSPATH: '/usr/share/java/cp-base-new/*:/usr/share/java/confluent-security/kafka-rest/*:/usr/share/java/kafka-rest/*'
       
       # Enable OAuth for REST Proxy's embedded Kafka client that accesses and manages consumer groups and topics
       KAFKA_REST_CLIENT_SECURITY_PROTOCOL: SASL_SSL


### PR DESCRIPTION
With our UBI images , the jars needed for "Cub" are in /usr/share/java/cp-base-new/* , but current cp-demo points to /etc/confluent/docker/docker-utils.jar

Since 6.0.x is using UBI images by default, we need to switch this for cp-demo to work.

Validated by manually editing docker-compose with these changes and making sure ZK and Kafka ready were working correctly.  