### PR TITLE
[DEVX-1889] Update restproxy creds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -906,8 +906,8 @@ services:
       KAFKA_REST_CLIENT_SASL_LOGIN_CALLBACK_HANDLER_CLASS: io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
       KAFKA_REST_CLIENT_SASL_JAAS_CONFIG: |
               org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
-              username="connectAdmin" \
-              password="connectAdmin" \
+              username="restAdmin" \
+              password="restAdmin" \
               metadataServerUrls="http://kafka1:8091,http://kafka2:8092";
       KAFKA_REST_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
 
@@ -921,7 +921,7 @@ services:
       KAFKA_REST_CLIENT_CONFLUENT_METADATA_SERVER_URLS_MAX_AGE_MS: 60000
       KAFKA_REST_CONFLUENT_METADATA_BOOTSTRAP_SERVER_URLS: http://kafka1:8091,http://kafka2:8092
       KAFKA_REST_CONFLUENT_METADATA_HTTP_AUTH_CREDENTIALS_PROVIDER: BASIC
-      KAFKA_REST_CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: 'connectAdmin:connectAdmin'
+      KAFKA_REST_CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: 'restAdmin:restAdmin'
 
 
   streams-demo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -388,7 +388,7 @@ services:
       CONNECT_PLUGIN_PATH: "/usr/share/java,/connect-plugins,/usr/share/confluent-hub-components"
       CONNECT_LOG4J_ROOT_LOGLEVEL: INFO
       CONNECT_LOG4J_LOGGERS: org.reflections=ERROR
-      CLASSPATH: "/usr/share/confluent-hub-components/confluentinc-kafka-connect-replicator/lib/replicator-rest-extension-${CONNECTOR_VERSION}.jar:/usr/share/java/monitoring-interceptors/monitoring-interceptors-${CONFLUENT}.jar"
+      CLASSPATH: "/usr/share/confluent-hub-components/confluentinc-kafka-connect-replicator/lib/replicator-rest-extension-${CONNECTOR_VERSION}.jar:/usr/share/java/monitoring-interceptors/*"
 
       # Connect Worker
       CONNECT_SECURITY_PROTOCOL: SASL_SSL

--- a/scripts/security/ldap_users/20_group_add.ldif
+++ b/scripts/security/ldap_users/20_group_add.ldif
@@ -61,6 +61,11 @@ memberuid: cn=controlcenterAdmin,ou=users,{{ LDAP_BASE_DN }}
 dn: cn=KafkaDevelopers,ou=groups,{{ LDAP_BASE_DN }}
 changetype: modify
 add: memberuid
+memberuid: cn=restAdmin,ou=users,{{ LDAP_BASE_DN }}
+
+dn: cn=KafkaDevelopers,ou=groups,{{ LDAP_BASE_DN }}
+changetype: modify
+add: memberuid
 memberuid: cn=appSA,ou=users,{{ LDAP_BASE_DN }}
 
 dn: cn=KafkaDevelopers,ou=groups,{{ LDAP_BASE_DN }}

--- a/scripts/security/ldap_users/21_restAdmin.ldif
+++ b/scripts/security/ldap_users/21_restAdmin.ldif
@@ -1,0 +1,15 @@
+dn: cn=restAdmin,ou=users,{{ LDAP_BASE_DN }}
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: restAdmin
+sn: Sheen
+givenName: restAdmin
+cn: restAdmin
+displayName: restAdmin Sheen
+uidNumber: 10021
+gidNumber: 5000
+userPassword: restAdmin
+gecos: restAdmin
+loginShell: /bin/bash
+homeDirectory: /home/restAdmin

--- a/scripts/validate/validate_bindings.sh
+++ b/scripts/validate/validate_bindings.sh
@@ -25,6 +25,7 @@ SR_PRINCIPAL="User:schemaregistryUser"
 KSQLDB_ADMIN="User:ksqlDBAdmin"
 KSQLDB_USER="User:ksqlDBUser"
 C3_ADMIN="User:controlcenterAdmin"
+REST_ADMIN="User:restAdmin"
 CLIENT_PRINCIPAL="User:appSA"
 BADAPP="User:badapp"
 LISTEN_PRINCIPAL="User:clientListen"
@@ -33,7 +34,7 @@ docker-compose exec tools bash -c ". /tmp/helper/functions.sh ; mds_login $MDS_U
 
 ################################## Run through permutations #############################
 
-for p in $SUPER_USER_PRINCIPAL $CONNECT_ADMIN $CONNECTOR_SUBMITTER $CONNECTOR_PRINCIPAL $SR_PRINCIPAL $KSQLDB_ADMIN $KSQLDB_USER $C3_ADMIN $CLIENT_PRINCIPAL $BADAPP $LISTEN_PRINCIPAL; do
+for p in $SUPER_USER_PRINCIPAL $CONNECT_ADMIN $CONNECTOR_SUBMITTER $CONNECTOR_PRINCIPAL $SR_PRINCIPAL $KSQLDB_ADMIN $KSQLDB_USER $C3_ADMIN $REST_ADMIN $CLIENT_PRINCIPAL $BADAPP $LISTEN_PRINCIPAL; do
   for c in " " " --schema-registry-cluster-id $SR" " --connect-cluster-id $CONNECT" " --ksql-cluster-id $KSQLDB"; do
     echo
     echo "Showing bindings for principal $p and --kafka-cluster-id $KAFKA_CLUSTER_ID $c"


### PR DESCRIPTION
This switches rest proxy to use it's own LDAP user and adds the user to LDAP.  In the future, may need to have specific role bindings for rest proxy, so this enables that and is a better separation vs. using connect admin.

Testing: With this change, brought up cp-demo and walked through security section in documentation with all rest proxy commands.

Includes on other minor change to add a wildcard for monitor-interceptors in connect classpath (since there is only one jar, this just makes it easier in case version matching is not exact)