### PR TITLE
[DEVX-1887] updated cp-demo to use license manager instead of ZK for trial license - SR & Rest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -784,8 +784,7 @@ services:
       KSQL_KSQL_SECURITY_EXTENSION_CLASS: io.confluent.ksql.security.KsqlConfluentSecurityExtension
 
       # Enable bearer token authentication which allows the identity of the ksqlDB end user to be propagated to Kafka for authorization
-      KSQL_REST_SERVLET_INITIALIZOR_CLASSES: io.confluent.common.security.jetty.initializer.InstallBearerOrBasicSecurityHandler
-      KSQL_WEBSOCKET_SERVLET_INITIALIZOR_CLASSES: io.confluent.common.security.jetty.initializer.InstallBearerOrBasicSecurityHandler
+      KSQL_KSQL_AUTHENTICATION_PLUGIN_CLASS: io.confluent.ksql.security.VertxBearerOrBasicAuthenticationPlugin
       KSQL_OAUTH_JWT_PUBLIC_KEY_PATH: /tmp/conf/public.pem
       KSQL_CONFLUENT_METADATA_PUBLIC_KEY_PATH: /tmp/conf/public.pem
       KSQL_PUBLIC_KEY_PATH: /tmp/conf/public.pem
@@ -893,8 +892,6 @@ services:
       KAFKA_REST_CLIENT_SSL_KEYSTORE_PASSWORD: confluent
       KAFKA_REST_CLIENT_SSL_KEY_PASSWORD: confluent
 
-      # ZooKeeper required to validate trial license
-      KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper:2181
 
       # Credentials and classpath for cub kafka-ready
       CUB_CLASSPATH: '/usr/share/java/cp-base-new/*:/usr/share/java/confluent-security/kafka-rest/*:/usr/share/java/kafka-rest/*'

--- a/scripts/helper/create-role-bindings.sh
+++ b/scripts/helper/create-role-bindings.sh
@@ -14,6 +14,7 @@ CONNECT=connect-cluster
 SR=schema-registry
 KSQLDB=ksql-cluster
 C3=c3-cluster
+LICENSE_RESOURCE="Topic:_confluent-license"
 
 SUPER_USER=superUser
 SUPER_USER_PASSWORD=superUser
@@ -78,21 +79,12 @@ do
         --kafka-cluster-id $KAFKA_CLUSTER_ID
 done
 
-for resource in Topic:_confluent-license
+for role in DeveloperRead DeveloperWrite
 do
     confluent iam rolebinding create \
         --principal $SR_PRINCIPAL \
-        --role DeveloperRead \
-        --resource $resource \
-        --kafka-cluster-id $KAFKA_CLUSTER_ID
-done
-
-for resource in Topic:_confluent-license
-do
-    confluent iam rolebinding create \
-        --principal $SR_PRINCIPAL \
-        --role DeveloperWrite \
-        --resource $resource \
+        --role $role \
+        --resource $LICENSE_RESOURCE \
         --kafka-cluster-id $KAFKA_CLUSTER_ID
 done
 
@@ -419,25 +411,14 @@ confluent iam rolebinding create \
 
 ############################## Rest Proxy ###############################
 echo "Creating role bindings for Rest Proxy"
-for resource in Topic:_confluent-license
+for role in DeveloperRead DeveloperWrite
 do
     confluent iam rolebinding create \
         --principal $REST_ADMIN \
-        --role DeveloperRead \
-        --resource $resource \
+        --role $role \
+        --resource $LICENSE_RESOURCE \
         --kafka-cluster-id $KAFKA_CLUSTER_ID
 done
-
-for resource in Topic:_confluent-license
-do
-    confluent iam rolebinding create \
-        --principal $REST_ADMIN \
-        --role DeveloperWrite \
-        --resource $resource \
-        --kafka-cluster-id $KAFKA_CLUSTER_ID
-done
-
-
 
 ################################### Client ###################################
 echo "Creating role bindings for the streams-demo application"

--- a/scripts/helper/create-role-bindings.sh
+++ b/scripts/helper/create-role-bindings.sh
@@ -26,6 +26,7 @@ KSQLDB_ADMIN="User:ksqlDBAdmin"
 KSQLDB_USER="User:ksqlDBUser"
 KSQLDB_SERVER="User:ksqlDBserver"
 C3_ADMIN="User:controlcenterAdmin"
+REST_ADMIN="User:restAdmin"
 CLIENT_PRINCIPAL="User:appSA"
 LISTEN_PRINCIPAL="User:clientListen"
 
@@ -73,6 +74,24 @@ do
     confluent iam rolebinding create \
         --principal $SR_PRINCIPAL \
         --role ResourceOwner \
+        --resource $resource \
+        --kafka-cluster-id $KAFKA_CLUSTER_ID
+done
+
+for resource in Topic:_confluent-license
+do
+    confluent iam rolebinding create \
+        --principal $SR_PRINCIPAL \
+        --role DeveloperRead \
+        --resource $resource \
+        --kafka-cluster-id $KAFKA_CLUSTER_ID
+done
+
+for resource in Topic:_confluent-license
+do
+    confluent iam rolebinding create \
+        --principal $SR_PRINCIPAL \
+        --role DeveloperWrite \
         --resource $resource \
         --kafka-cluster-id $KAFKA_CLUSTER_ID
 done
@@ -398,6 +417,28 @@ confluent iam rolebinding create \
     --role SystemAdmin \
     --kafka-cluster-id $KAFKA_CLUSTER_ID
 
+############################## Rest Proxy ###############################
+echo "Creating role bindings for Rest Proxy"
+for resource in Topic:_confluent-license
+do
+    confluent iam rolebinding create \
+        --principal $REST_ADMIN \
+        --role DeveloperRead \
+        --resource $resource \
+        --kafka-cluster-id $KAFKA_CLUSTER_ID
+done
+
+for resource in Topic:_confluent-license
+do
+    confluent iam rolebinding create \
+        --principal $REST_ADMIN \
+        --role DeveloperWrite \
+        --resource $resource \
+        --kafka-cluster-id $KAFKA_CLUSTER_ID
+done
+
+
+
 ################################### Client ###################################
 echo "Creating role bindings for the streams-demo application"
 
@@ -516,6 +557,7 @@ echo "    Connector Principal: $CONNECTOR_PRINCIPAL"
 echo "    ksqlDB Admin: $KSQLDB_ADMIN"
 echo "    ksqlDB User: $KSQLDB_USER"
 echo "    C3 Admin: $C3_ADMIN"
+echo "    Rest Admin: $REST_ADMIN"
 echo "    Client service account: $CLIENT_PRINCIPAL"
 echo "    Listen Client service account: $LISTEN_PRINCIPAL"
 echo


### PR DESCRIPTION
In order for SR and Rest Proxy to use the confluent license manager for trial license management, they need read/write access on the _confluent_license topic. This adds those role bindings.

Testing: Confirmed before this change that rest / SR failed to start due to lack of topic access and with this change both SR and Rest start fine (get past licensing) - Demo Not fully tested e-2-e

One additional change added here to modify ksql authorization to support a recent switch to vert.x auth

Testing: Internal error before this change due jetty no longer being available. Authorization was successful after this change.

