### PR TITLE
Add troubleshooting URL to cp-demo

### DIFF
--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -11,7 +11,7 @@ retry() {
     do
         if (( curr_wait >= max_wait ))
         then
-            echo "ERROR: Failed after $curr_wait seconds. Please troubleshoot and run again."
+            echo "ERROR: Failed after $curr_wait seconds. Please troubleshoot and run again. For troubleshooting instructions see https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html#troubleshooting"
             return 1
         else
             printf "."

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -24,7 +24,7 @@ openssl rsa -in ${DIR}/security/keypair/keypair.pem -outform PEM -pubout -out ${
 docker-compose up -d openldap
 sleep 5
 if [[ $(docker-compose ps openldap | grep Exit) =~ "Exit" ]] ; then
-  echo "ERROR: openldap container could not start. Troubleshoot and try again."
+  echo "ERROR: openldap container could not start. Troubleshoot and try again. For troubleshooting instructions see https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html#troubleshooting"
   exit 1
 fi
 
@@ -45,13 +45,13 @@ echo "Building custom Docker image with Connect version ${CONFLUENT_DOCKER_TAG} 
 if [[ "${CONNECTOR_VERSION}" =~ "SNAPSHOT" ]]; then
   echo "docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f Dockerfile-local ."
   docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f Dockerfile-local . || {
-    echo "ERROR: Docker image build failed. Please troubleshoot and try again."
+    echo "ERROR: Docker image build failed. Please troubleshoot and try again. For troubleshooting instructions see https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html#troubleshooting"
     exit 1;
   }
 else
   echo "docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f ${DIR}/../Dockerfile-confluenthub ."
   docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f ${DIR}/../Dockerfile-confluenthub . || {
-    echo "ERROR: Docker image build failed. Please troubleshoot and try again."
+    echo "ERROR: Docker image build failed. Please troubleshoot and try again. For troubleshooting instructions see https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html#troubleshooting"
     exit 1;
   }
 fi

--- a/scripts/validate/validate_connectors_running.sh
+++ b/scripts/validate/validate_connectors_running.sh
@@ -3,7 +3,7 @@
 for connector in wikipedia-irc replicate-topic elasticsearch-ksqldb; do
   STATE=$(docker-compose exec connect curl -X GET --cert /etc/kafka/secrets/connect.certificate.pem --key /etc/kafka/secrets/connect.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u superUser:superUser https://connect:8083/connectors/$connector/status | jq -r .connector.state)
   if [[ "$STATE" != "RUNNING" ]]; then
-    echo "Connector $connector is in $STATE state but it should be in RUNNING.  Please troubleshoot"
+    echo "Connector $connector is in $STATE state but it should be in RUNNING.  Please troubleshoot. For troubleshooting instructions see https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html#troubleshooting"
     exit 1
   else
     echo "Connector $connector is in $STATE state"


### PR DESCRIPTION
## Background

At the moment if `cp-demo` fails it tells the user `Please troubleshoot and run again.`, but it doesn't tell them *how* to troubleshoot. Users _may_ be following [the docs](https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html) already and see the [troubleshooting](https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html#troubleshooting) section - but they may not :) In this case users may simply abandon the demo, or turn to the community for help: 

![image](https://user-images.githubusercontent.com/3671582/86340669-2eafd380-bc4d-11ea-97b4-66652dbe781c.png)

We can smooth the user's journey by providing the link to the troubleshooting doc directly. They may still need help (and we should consider expanding this feedback message perhaps to direct them to http://cnfl.io/slack if they are still stuck?), but this at least gets them on the right tracks. 

If the URL of the troubleshooting doc changes then best-practices would dictate that a redirect is created anyway. If not, then a simple PR against cp-demo can be created to update it as required. 

## Testing done

### Failure

1. `./scripts/start.sh`. Wait for it to get to 

        Creating kafka-client   ... done
        Creating schemaregistry ... done
        Creating connect        ... done
        Creating control-center ... done
        Waiting up to 300 seconds for Confluent Control Center to start
        ..........

2. In separate window `docker stop control-center`

3. Script fails as expected and shows URL to help user. 

        Creating kafka-client   ... done
        Creating schemaregistry ... done
        Creating connect        ... done
        Creating control-center ... done
        Waiting up to 300 seconds for Confluent Control Center to start
        ............................................................ERROR: Failed after 300 seconds. Please troubleshoot and run again. For troubleshooting instructions see https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html#troubleshooting

### Success

1. `./scripts/start.sh`
2. Successful startup

        *****************************************************************************************************************
        DONE! Connect to Confluent Control Center at http://localhost:9021 (login as superUser/superUser for full access)
        *****************************************************************************************************************