### PR TITLE
Removed python check and doc-mention

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,7 +57,6 @@ Demo validated with:
 -  Java version 1.8.0_92
 -  MacOS 10.15.3 (note for `Ubuntu environments <https://github.com/confluentinc/cp-demo/issues/53>`__)
 -  OpenSSL 1.1.1d
--  Python 3.7.6
 -  git
 -  jq
 

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -35,7 +35,7 @@ verify_installed()
 preflight_checks()
 {
   # Verify appropriate tools are installed on host
-  for cmd in jq docker-compose keytool docker openssl python; do
+  for cmd in jq docker-compose keytool docker openssl; do
     verify_installed $cmd || exit 1
   done
 


### PR DESCRIPTION
I suspect that since:

```
commit be92587f6fbe2884df8b6e9374d0f12a38675245
Author: Yeva Byzek <ybyzek@users.noreply.github.com>
Date:   Tue Apr 14 22:44:16 2020 -0400

    DEVX-1707: Remove scripts/app/map_topics_clients.py from cp-demo (#196)
```

... `cp-demo` does not currently have any _launch-time_ dependencies on a Python runtime, so the check could be removed.  There is a reference in the docs Makefile, but that's a separate concern.

This came up when I attempted to launch on one of the Linux flavours which packages Python 3 such that binaries are `python3` and there is no `python` (and deprecated Python 2 is not installed).  I could create a symlink, but it looks like this check is now redundant anyway since the above removal of a Python script.