### PR TITLE
modify ksqlDB CUB_CLASSPATH given relocation of security plugins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -758,7 +758,7 @@ services:
     ports:
       - 8088:8088
     environment:
-      CUB_CLASSPATH: '/usr/share/java/ksqldb-server/*:/usr/share/java/cp-base-new/*'
+      CUB_CLASSPATH: '/usr/share/java/confluent-security/ksql/*:/usr/share/java/ksqldb-server/*:/usr/share/java/cp-base-new/*'
       KSQL_LOG4J_ROOT_LOGLEVEL: INFO
 
       KSQL_KSQL_SERVICE_ID: "ksql-cluster"


### PR DESCRIPTION
Once https://github.com/confluentinc/ksql-images/pull/55 is merged, security plugins will be installed in a separate directory, so we will need to modify cub classpath to include the security plugins.  Verified with private ksqldb images built from that PR.  