### PR TITLE
DEVX-2016: Bump CONNECTOR_VERSION

### DIFF
--- a/env_files/config.env
+++ b/env_files/config.env
@@ -21,4 +21,4 @@ CP_VERSION_FULL="$CONFLUENT_MAJOR.$CONFLUENT_MINOR.$CONFLUENT_PATCH"
 # The '/' which separates the REPOSITORY from the image name is not required here
 REPOSITORY=confluentinc
 
-CONNECTOR_VERSION=5.5.0
+CONNECTOR_VERSION=6.0.0-SNAPSHOT

--- a/env_files/config.env
+++ b/env_files/config.env
@@ -21,4 +21,6 @@ CP_VERSION_FULL="$CONFLUENT_MAJOR.$CONFLUENT_MINOR.$CONFLUENT_PATCH"
 # The '/' which separates the REPOSITORY from the image name is not required here
 REPOSITORY=confluentinc
 
+# If CONNECTOR_VERSION ~ `SNAPSHOT` then cp-demo uses Dockerfile-local
+# and expects user to build and provide a local file confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
 CONNECTOR_VERSION=6.0.0-SNAPSHOT

--- a/env_files/config.env
+++ b/env_files/config.env
@@ -16,11 +16,3 @@ CONFLUENT_PATCH=0
 #####################################################
 
 CP_VERSION_FULL="$CONFLUENT_MAJOR.$CONFLUENT_MINOR.$CONFLUENT_PATCH"
-
-# REPOSITORY - repository (probably) for Docker images
-# The '/' which separates the REPOSITORY from the image name is not required here
-REPOSITORY=confluentinc
-
-# If CONNECTOR_VERSION ~ `SNAPSHOT` then cp-demo uses Dockerfile-local
-# and expects user to build and provide a local file confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
-CONNECTOR_VERSION=6.0.0-SNAPSHOT

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -4,6 +4,14 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/helper/functions.sh
 source ${DIR}/../env_files/config.env
 
+# REPOSITORY - repository (probably) for Docker images
+# The '/' which separates the REPOSITORY from the image name is not required here
+export REPOSITORY=${REPOSITORY:-confluentinc}
+
+# If CONNECTOR_VERSION ~ `SNAPSHOT` then cp-demo uses Dockerfile-local
+# and expects user to build and provide a local file confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
+export CONNECTOR_VERSION=${CONNECTOR_VERSION:-$CONFLUENT}
+
 # Do preflight checks
 preflight_checks || exit
 


### PR DESCRIPTION
CONNECTOR_VERSION was incorrect for the 6.0.x branch

@rspurgeon this implements the solution we discussed today

@sdanduConf note that this enforces the proper workflow for testing cp-demo pre-GA, which requires user environment to have a local build of Replicator