### PR TITLE
DEVX-2082: Upgrade cp-demo-kstreams to latest based on 6.0 (0.0.7 image version)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -991,7 +991,7 @@ services:
 
 
   streams-demo:
-    image: cnfldemos/cp-demo-kstreams:0.0.6
+    image: cnfldemos/cp-demo-kstreams:0.0.7
     restart: always
     cpus: 0.4
     depends_on:


### PR DESCRIPTION
Verified running streams-demo and wikipedia-monitor consumer group