### PR TITLE
DEVX-1778; bump cp-demo-kstreams container v

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -927,7 +927,7 @@ services:
 
 
   streams-demo:
-    image: cnfldemos/cp-demo-kstreams:0.0.7
+    image: cnfldemos/cp-demo-kstreams:0.0.8
     restart: always
     cpus: 0.4
     depends_on:


### PR DESCRIPTION
Companion PR from changes in https://github.com/confluentinc/demos-common/pull/5
Changed docker image pushed to docker hub here: https://hub.docker.com/layers/cnfldemos/cp-demo-kstreams/0.0.8/images/sha256-5b4ff1a875a9716aa2b8f144606d18a609447b9f6d88a19b429896eaa581e805?context=repo