### PR TITLE
Make certificate generation parallel and faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 **/keypair/
 ui/expanded
 *.zip
+*.log

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -35,7 +35,7 @@ verify_installed()
 preflight_checks()
 {
   # Verify appropriate tools are installed on host
-  for cmd in jq docker-compose keytool docker openssl; do
+  for cmd in jq docker-compose keytool docker openssl xargs; do
     verify_installed $cmd || exit 1
   done
 

--- a/scripts/security/certs-create.sh
+++ b/scripts/security/certs-create.sh
@@ -6,13 +6,12 @@
 #    -o xtrace
 
 # Cleanup files
-rm -f *.crt *.csr *_creds *.jks *.srl *.key *.pem *.der *.p12
+rm -f *.crt *.csr *_creds *.jks *.srl *.key *.pem *.der *.p12 *.log
 
 # Generate CA key
 openssl req -new -x509 -keyout snakeoil-ca-1.key -out snakeoil-ca-1.crt -days 365 -subj '/CN=ca1.test.confluentdemo.io/OU=TEST/O=CONFLUENT/L=PaloAlto/ST=Ca/C=US' -passin pass:confluent -passout pass:confluent
 
-for i in kafka1 kafka2 client schemaregistry restproxy connect connectorSA controlcenter ksqlDBserver ksqlDBUser appSA badapp clientListen zookeeper mds
-do
-  echo "------------------------------- $i -------------------------------"
-  ./certs-create-per-user.sh $i
-done
+users=(kafka1 kafka2 client schemaregistry restproxy connect connectorSA controlcenter ksqlDBserver ksqlDBUser appSA badapp clientListen zookeeper mds)
+echo "Creating certificates"
+printf '%s\0' "${users[@]}" | xargs -0 -I{} -n1 -P15 sh -c './certs-create-per-user.sh "$1" > "certs-create-$1.log" 2>&1 && echo "Created certificates for $1"' -- {}
+echo "Creating certificates completed"


### PR DESCRIPTION
### Description 

Use xargs in parallel mode to create certificates in-parallel in the background.  Certificate generation currently occurs as a large serial batch near the start of the `cp-demo` launch script, and can take some time.  Here's some comparison timings:

Before:

```
$ time ./certs-create.sh
Generating a 2048 bit RSA private key
...................................................+++
......+++
writing new private key to 'snakeoil-ca-1.key'
-----
------------------------------- kafka1 -------------------------------
Signature ok
subject=/C=US/ST=Ca/L=PaloAlto/O=CONFLUENT/OU=TEST/CN=kafka1
Getting CA Private Key
Certificate was added to keystore
Certificate reply was installed in keystore
Certificate was added to keystore
Certificate stored in file <kafka1.der>
Importing keystore kafka.kafka1.keystore.jks to kafka1.keystore.p12...
Entry for alias kafka1 successfully imported.
Entry for alias caroot successfully imported.
Import command completed:  2 entries successfully imported, 0 entries failed or cancelled
MAC verified OK
------------------------------- kafka2 -------------------------------
----- >-8 ----- >-8 ----- >-8 ----- >-8 ----- >-8 ----- >-8 ----- >-8 ----- >-8 ----- 
real	1m7.469s
user	2m11.635s
sys	0m13.037s
```

After:

```
$ time ./certs-create.sh
Generating a 2048 bit RSA private key
.....................................................+++
...........+++
writing new private key to 'snakeoil-ca-1.key'
-----
Creating certificates
Created certificates for connectorSA
Created certificates for ksqlDBserver
Created certificates for connect
Created certificates for clientListen
Created certificates for appSA
Created certificates for badapp
Created certificates for controlcenter
Created certificates for mds
Created certificates for ksqlDBUser
Created certificates for kafka1
Created certificates for schemaregistry
Created certificates for kafka2
Created certificates for client
Created certificates for restproxy
Created certificates for zookeeper
Creating certificates completed

real	0m19.411s
user	3m46.406s
sys	0m30.359s
```

Note that the change is also moving a lot of stdout output to log files.

So time on a standard macOS machine dropped from 1m7s to 19s.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
[X] Run cp-demo


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
