### PR TITLE
DEVX-1368: cp-demo: revert running ksqlDB commands back to RUN SCRIPT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -852,7 +852,6 @@ services:
       - ksqldb-server
     volumes:
       - ./scripts/ksqlDB/statements.sql:/tmp/statements.sql
-      - ./scripts/ksqlDB/run_ksqlDB_commands.sh:/tmp/run_ksqlDB_commands.sh
     entrypoint: /bin/sh
     tty: true
 

--- a/scripts/ksqlDB/run_ksqlDB.sh
+++ b/scripts/ksqlDB/run_ksqlDB.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-# Cannot reliably use 'run script' until https://github.com/confluentinc/ksql/issues/4029 is resolved
-docker-compose exec ksqldb-cli bash -c "/tmp/run_ksqlDB_commands.sh"
+docker-compose exec ksqldb-cli bash -c "ksql -u ksqlDBUser -p ksqlDBUser http://ksqldb-server:8088 <<EOF
+RUN SCRIPT '/tmp/statements.sql';
+exit ;
+EOF
+"

--- a/scripts/ksqlDB/run_ksqlDB_commands.sh
+++ b/scripts/ksqlDB/run_ksqlDB_commands.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-input=/tmp/statements.sql
-while IFS= read -r line
-do
-  echo -e "$line\nexit" | ksql -u ksqlDBUser -p ksqlDBUser http://ksqldb-server:8088
-done < "$input"


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-1368

_What behavior does this PR change, and why?_

Run ksqlDB commands as RUN SCRIPT

With PR:

```
real    1m23.779s
user    0m0.534s
sys     0m0.097s
```

Without PR:

```
real    3m19.011s
user    0m0.639s
sys     0m0.132s
```

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [x] Run cp-demo


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] Run cp-demo

