### PR TITLE
DEVX-2203: replace -CAcreateserial with parallel-safe random

### DIFF
--- a/scripts/security/certs-create-per-user.sh
+++ b/scripts/security/certs-create-per-user.sh
@@ -26,6 +26,7 @@ if [[ "$i" == "mds" ]]; then
 fi
 
 # Sign the host certificate with the certificate authority (CA)
+# Set a random serial number (avoid problems from using '-CAcreateserial' when parallelizing certificate generation)
 CERT_SERIAL=$(awk -v seed="$RANDOM" 'BEGIN { srand(seed); printf("0x%.4x%.4x%.4x%.4x\n", rand()*65535 + 1, rand()*65535 + 1, rand()*65535 + 1, rand()*65535 + 1) }')
 openssl x509 -req -CA ${CA_PATH}/snakeoil-ca-1.crt -CAkey ${CA_PATH}/snakeoil-ca-1.key -in $i.csr -out $i-ca1-signed.crt -days 9999 -set_serial ${CERT_SERIAL} -passin pass:confluent -extensions v3_req -extfile <(cat <<EOF
 [req]

--- a/scripts/security/certs-create-per-user.sh
+++ b/scripts/security/certs-create-per-user.sh
@@ -26,7 +26,8 @@ if [[ "$i" == "mds" ]]; then
 fi
 
 # Sign the host certificate with the certificate authority (CA)
-openssl x509 -req -CA ${CA_PATH}/snakeoil-ca-1.crt -CAkey ${CA_PATH}/snakeoil-ca-1.key -in $i.csr -out $i-ca1-signed.crt -days 9999 -CAcreateserial -passin pass:confluent -extensions v3_req -extfile <(cat <<EOF
+CERT_SERIAL=$(awk -v seed="$RANDOM" 'BEGIN { srand(seed); printf("0x%.4x%.4x%.4x%.4x\n", rand()*65535 + 1, rand()*65535 + 1, rand()*65535 + 1, rand()*65535 + 1) }')
+openssl x509 -req -CA ${CA_PATH}/snakeoil-ca-1.crt -CAkey ${CA_PATH}/snakeoil-ca-1.key -in $i.csr -out $i-ca1-signed.crt -days 9999 -set_serial ${CERT_SERIAL} -passin pass:confluent -extensions v3_req -extfile <(cat <<EOF
 [req]
 distinguished_name = req_distinguished_name
 x509_extensions = v3_req


### PR DESCRIPTION
### Description 

openssl x509 ... option -CAcreateserial isn't parallel-friendly,  and cert-generation
was recently parallelized.  This created an overwrite/corruption condition on the
file used by -CAcreateserial, in our case:

>  unable to load number from ./snakeoil-ca-1.srl

Whilst a serial can be loaded from a specific file via -CAserial [file], it's
not clear how to interact this with -CAcreateserial option for a unique filename,
if that's even possible.

The serial has to be unique and <= 20 octets.  openssl seems to be generating
monotonic-increasing (time-based?) ones, but 8 octests random is plenty for our
demo certs.

Replaced with an awk script generating 8 octets, pass to -set_serial for each
cert.

https://confluentinc.atlassian.net/browse/DEVX-2203

_What behavior does this PR change, and why?_

Replaces `-CAcreateserial` option which uses a single filename so is unsafe, with a per-cert 80octet random number via `-set_serial`.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [X] Run cp-demo -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
