### PR TITLE
DEVX-2205: create Kafka topics while waiting for control-center and c…

### DIFF
--- a/scripts/helper/create_topics.sh
+++ b/scripts/helper/create_topics.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Create Kafka topic users, using appSA principal
+docker-compose exec kafka1 bash -c 'export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
+   --bootstrap-server kafka1:11091 \
+   --command-config /etc/kafka/secrets/appSA.config \
+   --topic users \
+   --create \
+   --replication-factor 2 \
+   --partitions 2 \
+   --config confluent.value.schema.validation=true'
+
+# Create Kafka topics with prefix wikipedia, using connectorSA principal
+docker-compose exec kafka1 bash -c 'export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
+   --bootstrap-server kafka1:11091 \
+   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
+   --topic wikipedia.parsed \
+   --create \
+   --replication-factor 2 \
+   --partitions 2 \
+   --config confluent.value.schema.validation=true'
+docker-compose exec kafka1 bash -c 'export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
+   --bootstrap-server kafka1:11091 \
+   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
+   --topic wikipedia.parsed.count-by-channel \
+   --create \
+   --replication-factor 2 \
+   --partitions 2'
+docker-compose exec kafka1 bash -c 'export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
+   --bootstrap-server kafka1:11091 \
+   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
+   --topic wikipedia.failed \
+   --create \
+   --replication-factor 2 \
+   --partitions 2'
+
+# Create Kafka topics with prefix WIKIPEDIA or EN_WIKIPEDIA, using ksqlDBUser principal
+for t in WIKIPEDIABOT WIKIPEDIANOBOT EN_WIKIPEDIA_GT_1 EN_WIKIPEDIA_GT_1_COUNTS
+do
+  docker-compose exec kafka1 bash -c 'export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
+     --bootstrap-server kafka1:11091 \
+     --command-config /etc/kafka/secrets/ksqlDBUser_without_interceptors_ssl.config \
+     --topic '"$t"' \
+     --create \
+     --replication-factor 2 \
+     --partitions 2'
+done

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -141,7 +141,7 @@ echo
 MAX_WAIT=30
 echo "Waiting up to $MAX_WAIT seconds for ksqlDB server to start"
 retry $MAX_WAIT host_check_ksqlDBserver_up || exit 1
-echo -e "\n\nRun ksqlDB queries (will take ~1 minute to return):"
+echo -e "\n\nRun ksqlDB queries:"
 ${DIR}/ksqlDB/run_ksqlDB.sh
 
 echo -e "\nStart consumers for additional topics: WIKIPEDIANOBOT, EN_WIKIPEDIA_GT_1_COUNTS"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -61,16 +61,6 @@ docker-compose exec kafka1 kafka-configs \
    --alter \
    --add-config min.insync.replicas=1
 
-# Create Kafka topic users, using appSA principal
-docker-compose exec kafka1 bash -c 'export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/appSA.config \
-   --topic users \
-   --create \
-   --replication-factor 2 \
-   --partitions 2 \
-   --config confluent.value.schema.validation=true'
-
 echo
 echo "Building custom Docker image with Connect version ${CONFLUENT_DOCKER_TAG} and connector version ${CONNECTOR_VERSION}"
 if [[ "${CONNECTOR_VERSION}" =~ "SNAPSHOT" ]]; then
@@ -87,6 +77,10 @@ else
   }
 fi
 docker-compose up -d schemaregistry connect control-center
+
+echo
+echo -e "Create topics in cluster"
+${DIR}/helper/create_topics.sh
 
 # Verify Confluent Control Center has started
 MAX_WAIT=300
@@ -120,30 +114,6 @@ docker-compose exec connect timeout 3 nc -zv irc.wikimedia.org 6667 || {
   exit 1
 }
 
-# Create Kafka topics with prefix wikipedia, using connectorSA principal
-docker-compose exec kafka1 bash -c 'export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
-   --topic wikipedia.parsed \
-   --create \
-   --replication-factor 2 \
-   --partitions 2 \
-   --config confluent.value.schema.validation=true'
-docker-compose exec kafka1 bash -c 'export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
-   --topic wikipedia.parsed.count-by-channel \
-   --create \
-   --replication-factor 2 \
-   --partitions 2'
-docker-compose exec kafka1 bash -c 'export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
-   --topic wikipedia.failed \
-   --create \
-   --replication-factor 2 \
-   --partitions 2'
-
 echo -e "\nStart streaming from the IRC source connector:"
 ${DIR}/connectors/submit_wikipedia_irc_config.sh
 
@@ -167,23 +137,11 @@ ${DIR}/dashboard/configure_kibana_dashboard.sh
 echo
 echo
 
-# Create Kafka topics with prefix WIKIPEDIA or EN_WIKIPEDIA, using ksqlDBUser principal
-for t in WIKIPEDIABOT WIKIPEDIANOBOT EN_WIKIPEDIA_GT_1 EN_WIKIPEDIA_GT_1_COUNTS
-do
-  docker-compose exec kafka1 bash -c 'export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-     --bootstrap-server kafka1:11091 \
-     --command-config /etc/kafka/secrets/ksqlDBUser_without_interceptors_ssl.config \
-     --topic '"$t"' \
-     --create \
-     --replication-factor 2 \
-     --partitions 2'
-done
-
 # Verify ksqlDB server has started
 MAX_WAIT=30
 echo "Waiting up to $MAX_WAIT seconds for ksqlDB server to start"
 retry $MAX_WAIT host_check_ksqlDBserver_up || exit 1
-echo -e "\n\nRun ksqlDB queries:"
+echo -e "\n\nRun ksqlDB queries (will take ~1 minute to return):"
 ${DIR}/ksqlDB/run_ksqlDB.sh
 
 echo -e "\nStart consumers for additional topics: WIKIPEDIANOBOT, EN_WIKIPEDIA_GT_1_COUNTS"


### PR DESCRIPTION
…onnect

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2205

_What behavior does this PR change, and why?_

Change order when Kafka topics are created.  Purpose is to reduce overall script time.  Creating the topics while Connect is starting results in reduction of run time by over 2 minutes. 

Without PR:

```
./scripts/start.sh  244.62s user 19.26s system 45% cpu 9:36.02 total
```

With PR:

```
./scripts/start.sh  242.04s user 19.18s system 60% cpu 7:11.16 total
```

Note: Connect is the long pole.  Even with this change, the script still waits for connect to start.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] Run cp-demo


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] Run cp-demo
