### PR TITLE
DEVX-2209: Improve self-signed certificates for better browser tolerance

### DIFF
--- a/scripts/security/certs-create-per-user.sh
+++ b/scripts/security/certs-create-per-user.sh
@@ -28,7 +28,7 @@ fi
 # Sign the host certificate with the certificate authority (CA)
 # Set a random serial number (avoid problems from using '-CAcreateserial' when parallelizing certificate generation)
 CERT_SERIAL=$(awk -v seed="$RANDOM" 'BEGIN { srand(seed); printf("0x%.4x%.4x%.4x%.4x\n", rand()*65535 + 1, rand()*65535 + 1, rand()*65535 + 1, rand()*65535 + 1) }')
-openssl x509 -req -CA ${CA_PATH}/snakeoil-ca-1.crt -CAkey ${CA_PATH}/snakeoil-ca-1.key -in $i.csr -out $i-ca1-signed.crt -days 365 -set_serial ${CERT_SERIAL} -passin pass:confluent -extensions v3_req -extfile <(cat <<EOF
+openssl x509 -req -CA ${CA_PATH}/snakeoil-ca-1.crt -CAkey ${CA_PATH}/snakeoil-ca-1.key -in $i.csr -out $i-ca1-signed.crt -sha256 -days 365 -set_serial ${CERT_SERIAL} -passin pass:confluent -extensions v3_req -extfile <(cat <<EOF
 [req]
 distinguished_name = req_distinguished_name
 x509_extensions = v3_req

--- a/scripts/security/certs-create-per-user.sh
+++ b/scripts/security/certs-create-per-user.sh
@@ -36,6 +36,7 @@ prompt = no
 [req_distinguished_name]
 CN = $i
 [v3_req]
+extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 [alt_names]
 $DNS_ALT_NAMES

--- a/scripts/security/certs-create-per-user.sh
+++ b/scripts/security/certs-create-per-user.sh
@@ -28,7 +28,7 @@ fi
 # Sign the host certificate with the certificate authority (CA)
 # Set a random serial number (avoid problems from using '-CAcreateserial' when parallelizing certificate generation)
 CERT_SERIAL=$(awk -v seed="$RANDOM" 'BEGIN { srand(seed); printf("0x%.4x%.4x%.4x%.4x\n", rand()*65535 + 1, rand()*65535 + 1, rand()*65535 + 1, rand()*65535 + 1) }')
-openssl x509 -req -CA ${CA_PATH}/snakeoil-ca-1.crt -CAkey ${CA_PATH}/snakeoil-ca-1.key -in $i.csr -out $i-ca1-signed.crt -days 9999 -set_serial ${CERT_SERIAL} -passin pass:confluent -extensions v3_req -extfile <(cat <<EOF
+openssl x509 -req -CA ${CA_PATH}/snakeoil-ca-1.crt -CAkey ${CA_PATH}/snakeoil-ca-1.key -in $i.csr -out $i-ca1-signed.crt -days 365 -set_serial ${CERT_SERIAL} -passin pass:confluent -extensions v3_req -extfile <(cat <<EOF
 [req]
 distinguished_name = req_distinguished_name
 x509_extensions = v3_req


### PR DESCRIPTION
### Description

_What behavior does this PR change, and why?_

`cp-demo` is secured (by RBAC) and Control Center can currently be accessed via http://localhost:9021, or over TLS via https://localhost:9022.  Obviously HTTPS is better to demonstrate security, but as a stand-up demo, all cp-demo's CAs are self-signed, so the certificates they sign aren't automatically trusted by browsers, and fair-enough!

It can however be useful when using the demo to carefully ignore and bypass these trust-warnings, accessing Control Center over HTTPS.  However, browsers are becoming stricter, and the path familiar especially to developers e.g

Chrome: Your connection is not private (error page)
-> Click Advanced
-> Read warning
-> Click link: Proceed to localhost (unsafe)

... is not even always offered anymore.  Browsers consider some settings or omissions on self-signed certificates so egregious, that they won't even offer the (unsafe) bypass link.  Some of these requirements are:

* at least SHA-2 hashes, not SHA-1
* 2048+ bit keys
* Proper server-usage extension
* Reasonable number of days of validity
* Must include SANs

This blog post has a good reference for what one platform requires: https://lukearmstrong.co.uk/2020/06/self-signed-ssl-certificate/

Note that fulfilling these does not make the browser trust the certificate (of course), but it does re-enable the backdoor/developer I'll-accept-my-own-self-signed-cert-on-localhost path, without needing to resort to custom browser settings or hidden flags (these also exist for some browsers).

This PR makes the required changes (to all user certs generated, there seems to be no harm in that)
- Reduce validity days from 9999 to 365 (825 is apparently the limit on OS/X).
- Use SHA-2/SHA-256 hashes
- Added a required extended key usage

To test this PR:

- On a Mac with current OS, using Chrome without custom settings, access Control Center at https://localhost:9022, and under Advanced on the warning page there should be no: "Proceed to localhost (unsafe)" link offered.
- Apply this PR and redeploy, and that link should then be available.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

[ ] Documentation
[X] Run cp-demo


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

[ ] Run cp-demo
