### PR TITLE
DEVX-2231: add CONTROL_CENTER_STREAMS_CPREST_URL for Self Balancing Clusters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -672,6 +672,9 @@ services:
       # Used by Control Center to connect to MDS to verify tokens and authenticate clients
       CONFLUENT_METADATA_BOOTSTRAP_SERVER_URLS: https://kafka1:8091,https://kafka2:8092
       CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: controlcenterAdmin:controlcenterAdmin
+
+      # Used by Control Center to connect to the Admin API for Self Balancing Clusters
+      CONTROL_CENTER_STREAMS_CPREST_URL: "https://kafka1:8091,https://kafka2:8092"
       
       CONTROL_CENTER_STREAMS_SECURITY_PROTOCOL: SASL_SSL
       CONTROL_CENTER_STREAMS_SASL_MECHANISM: OAUTHBEARER


### PR DESCRIPTION
### Description

This PR creates Control Center config property `confluent.controlcenter.streams.cprest.url` which is required for the Self Balancing Clusters UI.

_What behavior does this PR change, and why?_

This resolves a 403 unauthorized error from the C3 UI when accessing `/api/kafka-rest`.  With this property set, the Self Balancing Cluster feature is now enabled in the UI.

Note that this change doesn't perform any set-up for demo of the Self Balancing Cluster feature.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

[ ] Documentation
[x] Run cp-demo


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
