### PR TITLE
DEVX-2233: Reorder Dockerfile to reuse a cached layer

### DIFF
--- a/Dockerfile-confluenthub
+++ b/Dockerfile-confluenthub
@@ -21,12 +21,6 @@ ARG CONNECTOR_VERSION
 
 ENV CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
 
-# Add JDK default cacerts to kafka.connect.truststore.jks to allow outgoing HTTPS
-COPY scripts/security/kafka.connect.truststore.jks /tmp/kafka.connect.truststore.jks
-USER root
-RUN keytool -importkeystore -srckeystore /usr/lib/jvm/zulu11-ca/lib/security/cacerts -srcstorepass changeit -destkeystore /tmp/kafka.connect.truststore.jks -deststorepass confluent -keypass confluent
-USER appuser
-
 # Install SSE connector
 RUN confluent-hub install --no-prompt cjmatta/kafka-connect-sse:latest
 
@@ -38,3 +32,9 @@ RUN confluent-hub install --no-prompt confluentinc/kafka-connect-replicator:${CO
 
 # Install Elasticsearch connector
 RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:latest
+
+# Add JDK default cacerts to kafka.connect.truststore.jks to allow outgoing HTTPS
+COPY scripts/security/kafka.connect.truststore.jks /tmp/kafka.connect.truststore.jks
+USER root
+RUN keytool -importkeystore -srckeystore /usr/lib/jvm/zulu11-ca/lib/security/cacerts -srcstorepass changeit -destkeystore /tmp/kafka.connect.truststore.jks -deststorepass confluent -keypass confluent
+USER appuser

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -21,12 +21,6 @@ ARG CONNECTOR_VERSION
 
 ENV CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
 
-# Add JDK default cacerts to kafka.connect.truststore.jks to allow outgoing HTTPS
-COPY scripts/security/kafka.connect.truststore.jks /tmp/kafka.connect.truststore.jks
-USER root
-RUN keytool -importkeystore -srckeystore /usr/lib/jvm/zulu11-ca/lib/security/cacerts -srcstorepass changeit -destkeystore /tmp/kafka.connect.truststore.jks -deststorepass confluent -keypass confluent
-USER appuser
-
 # Install SSE connector
 RUN confluent-hub install --no-prompt cjmatta/kafka-connect-sse:latest
 
@@ -39,3 +33,9 @@ RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-replicator
 
 # Install Elasticsearch connector
 RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:latest
+
+# Add JDK default cacerts to kafka.connect.truststore.jks to allow outgoing HTTPS
+COPY scripts/security/kafka.connect.truststore.jks /tmp/kafka.connect.truststore.jks
+USER root
+RUN keytool -importkeystore -srckeystore /usr/lib/jvm/zulu11-ca/lib/security/cacerts -srcstorepass changeit -destkeystore /tmp/kafka.connect.truststore.jks -deststorepass confluent -keypass confluent
+USER appuser

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -62,7 +62,8 @@ docker-compose exec kafka1 kafka-configs \
    --add-config min.insync.replicas=1
 
 # Build custom Kafka Connect image with required jars
-build_connect_image || exit 1
+time build_connect_image || exit 1
+exit
 
 # Bring up more containers
 docker-compose up -d schemaregistry connect control-center

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -62,8 +62,7 @@ docker-compose exec kafka1 kafka-configs \
    --add-config min.insync.replicas=1
 
 # Build custom Kafka Connect image with required jars
-time build_connect_image || exit 1
-exit
+build_connect_image || exit 1
 
 # Bring up more containers
 docker-compose up -d schemaregistry connect control-center


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2233

_What behavior does this PR change, and why?_

- Without this fix, when certs copy precede Confluent Hub pulls, all connectors need to be redownloaded --> and connect image build takes 0m42.256s .
- With this fix, when Confluent Hub pulls precede certs copy, connectors do NOT need to be redownloaded --> add connect image build takes 0m10.422s .

Savings of about 30s

```
Step 5/12 : RUN confluent-hub install --no-prompt cjmatta/kafka-connect-sse:latest
 ---> Using cache
 ---> 74ac43129c60
Step 6/12 : RUN confluent-hub install --no-prompt jcustenborder/kafka-connect-json-schema:latest
 ---> Using cache
 ---> 1250919c105d
Step 7/12 : RUN confluent-hub install --no-prompt confluentinc/kafka-connect-replicator:${CONNECTOR_VERSION}
 ---> Using cache
 ---> 954e4168384f
Step 8/12 : RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:latest
 ---> Using cache
 ---> 0ace33b60b54
```

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] Run cp-demo


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] Run cp-demo
