### PR TITLE
DEVX-2247: Remove cert and key from SR command

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -678,8 +678,6 @@ The security in place between |sr| and the end clients, e.g. ``appSA``, is as fo
    .. code-block:: text
 
        docker-compose exec schemaregistry curl -X GET \
-          --cert /etc/kafka/secrets/schemaregistry.certificate.pem \
-          --key /etc/kafka/secrets/schemaregistry.key \
           --tlsv1.2 \
           --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
           -u superUser:superUser \
@@ -706,8 +704,6 @@ The security in place between |sr| and the end clients, e.g. ``appSA``, is as fo
 
        docker-compose exec schemaregistry curl -X POST \
           -H "Content-Type: application/vnd.schemaregistry.v1+json" \
-          --cert /etc/kafka/secrets/schemaregistry.certificate.pem \
-          --key /etc/kafka/secrets/schemaregistry.key \
           --tlsv1.2 \
           --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
           --data '{ "schema": "[ { \"type\":\"record\", \"name\":\"user\", \"fields\": [ {\"name\":\"userid\",\"type\":\"long\"}, {\"name\":\"username\",\"type\":\"string\"} ]} ]" }' \
@@ -726,8 +722,6 @@ The security in place between |sr| and the end clients, e.g. ``appSA``, is as fo
 
        docker-compose exec schemaregistry curl -X POST \
           -H "Content-Type: application/vnd.schemaregistry.v1+json" \
-          --cert /etc/kafka/secrets/schemaregistry.certificate.pem \
-          --key /etc/kafka/secrets/schemaregistry.key \
           --tlsv1.2 \
           --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
           --data '{ "schema": "[ { \"type\":\"record\", \"name\":\"user\", \"fields\": [ {\"name\":\"userid\",\"type\":\"long\"}, {\"name\":\"username\",\"type\":\"string\"} ]} ]" }' \
@@ -764,8 +758,6 @@ The security in place between |sr| and the end clients, e.g. ``appSA``, is as fo
 
        docker-compose exec schemaregistry curl -X POST \
           -H "Content-Type: application/vnd.schemaregistry.v1+json" \
-          --cert /etc/kafka/secrets/schemaregistry.certificate.pem \
-          --key /etc/kafka/secrets/schemaregistry.key \
           --tlsv1.2 \
           --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
           --data '{ "schema": "[ { \"type\":\"record\", \"name\":\"user\", \"fields\": [ {\"name\":\"userid\",\"type\":\"long\"}, {\"name\":\"username\",\"type\":\"string\"} ]} ]" }' \
@@ -788,8 +780,6 @@ The security in place between |sr| and the end clients, e.g. ``appSA``, is as fo
    .. code-block:: text
 
        docker-compose exec schemaregistry curl -X GET \
-          --cert /etc/kafka/secrets/schemaregistry.certificate.pem \
-          --key /etc/kafka/secrets/schemaregistry.key \
           --tlsv1.2 \
           --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
           -u appSA:appSA \

--- a/scripts/validate/validate_rest_proxy.sh
+++ b/scripts/validate/validate_rest_proxy.sh
@@ -43,10 +43,10 @@ docker-compose exec tools bash -c "confluent iam rolebinding create \
     --schema-registry-cluster-id $SR"
 
 # Register a new Avro schema for topic 'users'
-docker-compose exec schemaregistry curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --cert /etc/kafka/secrets/schemaregistry.certificate.pem --key /etc/kafka/secrets/schemaregistry.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt --data '{ "schema": "[ { \"type\":\"record\", \"name\":\"user\", \"fields\": [ {\"name\":\"userid\",\"type\":\"long\"}, {\"name\":\"username\",\"type\":\"string\"} ]} ]" }' -u $CLIENT_NAME:$CLIENT_NAME https://schemaregistry:8085/subjects/$subject/versions
+docker-compose exec schemaregistry curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt --data '{ "schema": "[ { \"type\":\"record\", \"name\":\"user\", \"fields\": [ {\"name\":\"userid\",\"type\":\"long\"}, {\"name\":\"username\",\"type\":\"string\"} ]} ]" }' -u $CLIENT_NAME:$CLIENT_NAME https://schemaregistry:8085/subjects/$subject/versions
 
 # Get the Avro schema id
-schemaid=$(docker-compose exec schemaregistry curl -X GET --cert /etc/kafka/secrets/schemaregistry.certificate.pem --key /etc/kafka/secrets/schemaregistry.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u $CLIENT_NAME:$CLIENT_NAME https://schemaregistry:8085/subjects/$subject/versions/1 | jq '.id')
+schemaid=$(docker-compose exec schemaregistry curl -X GET --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u $CLIENT_NAME:$CLIENT_NAME https://schemaregistry:8085/subjects/$subject/versions/1 | jq '.id')
 
 # Go through steps at https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html?utm_source=github&utm_medium=demo&utm_campaign=ch.cp-demo_type.community_content.cp-demo#confluent-rest-proxy
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2247

_What behavior does this PR change, and why?_

The following lines can be removed from curl commands to SR because `ssl.client.auth` is disabled:

```
--cert /etc/kafka/secrets/schemaregistry.certificate.pem \
--key /etc/kafka/secrets/schemaregistry.key \
```

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] Run cp-demo


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
