### PR TITLE
Switch to a cipher suite that Chrome supports.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -557,7 +557,7 @@ services:
                   -Djavax.net.ssl.trustStorePassword=confluent
                   -Djavax.net.ssl.keyStore=/etc/kafka/secrets/kafka.connect.keystore.jks
                   -Djavax.net.ssl.keyStorePassword=confluent
-      CONNECT_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+      CONNECT_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
 
       # Reduce Connect memory utilization
       KAFKA_JVM_PERFORMANCE_OPTS: -server -XX:+UseG1GC -XX:GCTimeRatio=1
@@ -620,7 +620,7 @@ services:
               username="controlcenterAdmin" \
               password="controlcenterAdmin" \
               metadataServerUrls="https://kafka1:8091,https://kafka2:8092";
-      CONTROL_CENTER_STREAMS_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+      CONTROL_CENTER_STREAMS_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
 
       CONTROL_CENTER_REPLICATION_FACTOR: 2
       CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
@@ -647,7 +647,7 @@ services:
       CONTROL_CENTER_REST_SSL_KEYSTORE_LOCATION: /etc/kafka/secrets/kafka.controlcenter.keystore.jks
       CONTROL_CENTER_REST_SSL_KEYSTORE_PASSWORD: confluent
       CONTROL_CENTER_REST_SSL_KEY_PASSWORD: confluent
-      CONTROL_CENTER_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+      CONTROL_CENTER_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
       PORT: 9021
 
       # Connect
@@ -730,7 +730,7 @@ services:
       SCHEMA_REGISTRY_SCHEMA_REGISTRY_INTER_INSTANCE_PROTOCOL: "https"
       SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL: INFO
       SCHEMA_REGISTRY_KAFKASTORE_TOPIC: _schemas
-      SCHEMA_REGISTRY_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+      SCHEMA_REGISTRY_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
 
       SCHEMA_REGISTRY_DEBUG: 'true'
 
@@ -906,7 +906,7 @@ services:
               username="restAdmin" \
               password="restAdmin" \
               metadataServerUrls="https://kafka1:8091,https://kafka2:8092";
-      KAFKA_REST_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+      KAFKA_REST_SSL_CIPHER_SUITES: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
 
       # Enable bearer token authentication which allows the identity of the REST Proxy end user to be propagated to Kafka for authorization
       KAFKA_REST_KAFKA_REST_RESOURCE_EXTENSION_CLASS: io.confluent.kafkarest.security.KafkaRestSecurityResourceExtension


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_

The SSL Cipher Suite specified in the docker-compose.yml file is not supported by Google Chrome, as it is apparently considered to be insecure. This PR changes the cipher suite to a similar one that is supported by Google Chrome to allow for connecting to e.g. the Schema Registry server from the browser for manual data exploration via the REST API.

### Author Validation

I have run the demo on Docker on Linux using the `scripts/start.sh` script and it continues to work fine after this change, with the notable difference that my Chrome browser will now allow me to make TLS connections to e.g. the schema registry on port 8085.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] Run cp-demo


### Reviewer Tasks

Accept this if it seems reasonable to you. It's a pretty low-risk, low-impact configuration change.

- [ ] Run cp-demo