### PR TITLE
DEVX-2277: Parallelize topic creation

### DIFF
--- a/scripts/helper/create-topic.sh
+++ b/scripts/helper/create-topic.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+config=$1
+topic=$2
+
+export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
+   --bootstrap-server kafka1:11091 \
+   --command-config /etc/kafka/secrets/$config \
+   --topic $topic \
+   --create \
+   --replication-factor 2 \
+   --partitions 2 \
+   --config confluent.value.schema.validation=true

--- a/scripts/helper/create-topics.sh
+++ b/scripts/helper/create-topics.sh
@@ -1,47 +1,18 @@
 #!/bin/bash
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cd $DIR
+
 # Create Kafka topic users, using appSA principal
-export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/appSA.config \
-   --topic users \
-   --create \
-   --replication-factor 2 \
-   --partitions 2 \
-   --config confluent.value.schema.validation=true
+./create-topic.sh appSA.config users
 
 # Create Kafka topics with prefix wikipedia, using connectorSA principal
-export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
-   --topic wikipedia.parsed \
-   --create \
-   --replication-factor 2 \
-   --partitions 2 \
-   --config confluent.value.schema.validation=true
-export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
-   --topic wikipedia.parsed.count-by-domain \
-   --create \
-   --replication-factor 2 \
-   --partitions 2
-export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
-   --topic wikipedia.failed \
-   --create \
-   --replication-factor 2 \
-   --partitions 2
+./create-topic.sh connectorSA_without_interceptors_ssl.config wikipedia.parsed
+./create-topic.sh connectorSA_without_interceptors_ssl.config wikipedia.parsed.count-by-domain
+./create-topic.sh connectorSA_without_interceptors_ssl.config wikipedia.failed
 
 # Create Kafka topics with prefix WIKIPEDIA or EN_WIKIPEDIA, using ksqlDBUser principal
 for t in WIKIPEDIABOT WIKIPEDIANOBOT EN_WIKIPEDIA_GT_1 EN_WIKIPEDIA_GT_1_COUNTS
 do
-  export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-     --bootstrap-server kafka1:11091 \
-     --command-config /etc/kafka/secrets/ksqlDBUser_without_interceptors_ssl.config \
-     --topic "$t" \
-     --create \
-     --replication-factor 2 \
-     --partitions 2
+  ./create-topic.sh ksqlDBUser_without_interceptors_ssl.config $t
 done

--- a/scripts/helper/create-topics.sh
+++ b/scripts/helper/create-topics.sh
@@ -3,16 +3,14 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 cd $DIR
 
-# Create Kafka topic users, using appSA principal
-./create-topic.sh appSA.config users
+topics=(appSA.config users \
+        connectorSA_without_interceptors_ssl.config wikipedia.parsed \
+        connectorSA_without_interceptors_ssl.config wikipedia.parsed.count-by-domain \
+        connectorSA_without_interceptors_ssl.config wikipedia.failed \
+        ksqlDBUser_without_interceptors_ssl.config WIKIPEDIABOT \
+        ksqlDBUser_without_interceptors_ssl.config WIKIPEDIANOBOT \
+        ksqlDBUser_without_interceptors_ssl.config EN_WIKIPEDIA_GT_1 \
+        ksqlDBUser_without_interceptors_ssl.config EN_WIKIPEDIA_GT_1_COUNTS \
+       )
 
-# Create Kafka topics with prefix wikipedia, using connectorSA principal
-./create-topic.sh connectorSA_without_interceptors_ssl.config wikipedia.parsed
-./create-topic.sh connectorSA_without_interceptors_ssl.config wikipedia.parsed.count-by-domain
-./create-topic.sh connectorSA_without_interceptors_ssl.config wikipedia.failed
-
-# Create Kafka topics with prefix WIKIPEDIA or EN_WIKIPEDIA, using ksqlDBUser principal
-for t in WIKIPEDIABOT WIKIPEDIANOBOT EN_WIKIPEDIA_GT_1 EN_WIKIPEDIA_GT_1_COUNTS
-do
-  ./create-topic.sh ksqlDBUser_without_interceptors_ssl.config $t
-done
+printf '%s\0' "${topics[@]}" | xargs -0 -n2 -P15 sh -c 'echo "Creating topic $2 with principal $1";./create-topic.sh "$1" "$2";echo "Created topic $2";' sh

--- a/scripts/helper/create-topics.sh
+++ b/scripts/helper/create-topics.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 cd $DIR

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -78,7 +78,7 @@ docker-compose up -d schemaregistry connect control-center
 
 echo
 echo -e "Create topics in Kafka cluster:"
-docker-compose exec kafka1 bash -c "/tmp/helper/create-topics.sh" || exit 1
+docker-compose exec tools bash -c "/tmp/helper/create-topics.sh" || exit 1
 
 # Verify Confluent Control Center has started
 MAX_WAIT=300


### PR DESCRIPTION
### Description 

`kafka-topics` can only create a single topic at a time, and can be slow-ish to start-up.  We can run topic-creation in parallel and shave 1-2 minutes off total start-up time.

_What behavior does this PR change, and why?_

Creates (same) topics but in parallel for shorter end-to-end startup time.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
[ ] Documentation
[X] Run cp-demo
[ ] jmx-monitoring-stacks


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
