### PR TITLE
Fix struct access syntax in ksqlDB query

### DIFF
--- a/scripts/ksqlDB/statements.sql
+++ b/scripts/ksqlDB/statements.sql
@@ -1,6 +1,6 @@
 CREATE STREAM wikipedia WITH (kafka_topic='wikipedia.parsed', value_format='AVRO');
 CREATE STREAM wikipedianobot AS SELECT *, (length->new - length->old) AS BYTECHANGE FROM wikipedia WHERE bot = false AND length IS NOT NULL AND length->new IS NOT NULL AND length->old IS NOT NULL;
 CREATE STREAM wikipediabot AS SELECT *, (length->new - length->old) AS BYTECHANGE FROM wikipedia WHERE bot = true AND length IS NOT NULL AND length->new IS NOT NULL AND length->old IS NOT NULL;
-CREATE TABLE en_wikipedia_gt_1 AS SELECT user, 'meta.uri' AS URI, count(*) AS COUNT FROM wikipedia WINDOW TUMBLING (size 300 second) WHERE 'meta.domain' = 'commons.wikimedia.org' GROUP BY user, 'meta.uri' HAVING count(*) > 1;
+CREATE TABLE en_wikipedia_gt_1 AS SELECT user, meta->uri AS URI, count(*) AS COUNT FROM wikipedia WINDOW TUMBLING (size 300 second) WHERE meta->domain = 'commons.wikimedia.org' GROUP BY user, meta->uri HAVING count(*) > 1;
 CREATE STREAM en_wikipedia_gt_1_stream (USER string, URI string, COUNT bigint) WITH (kafka_topic='EN_WIKIPEDIA_GT_1', value_format='AVRO');
 CREATE STREAM en_wikipedia_gt_1_counts AS SELECT * FROM en_wikipedia_gt_1_stream where ROWTIME is not null;


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

For whatever reason, one of the ksqlDB queries bundled with this demo did not use the proper syntax for accessing a struct property. The result was that part of the demo was broken. The query that creates the `en_wikipedia_gt_1` table never resulted in any data with the old syntax.

According to the [official documentation](https://docs.ksqldb.io/en/latest/how-to-guides/query-structured-data/) the proper syntax is `field->sub_field` not `'field.sub_field'`. I'm not sure why this other syntax is here in the example? Maybe the ksqlDB syntax changed and this example was not updated? I'm new to ksqlDB, and came across this as part of the process of evaluating it as a potential technology to incorporate into our operations.

### Author Validation

With the correction, the `en_wikipedia_gt_1` table and corresponding Kafka topic get populated with the expected data. Before the correction, the topic and table remained empty no matter how long the demo application ran.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->
