### PR TITLE
DEVX-2279: remove container cpu limits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: kafka1
     container_name: kafka1
-    cpus: 0.7
     depends_on:
       - zookeeper
       - openldap
@@ -234,7 +233,6 @@ services:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: kafka2
     container_name: kafka2
-    cpus: 0.7
     depends_on:
       - zookeeper
       - openldap
@@ -395,7 +393,6 @@ services:
   connect:
     image: localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION}
     container_name: connect
-    cpus: 0.9
     restart: always
     build:
       context: .
@@ -569,7 +566,6 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.0
     container_name: elasticsearch
-    cpus: 0.50
     #restart: always
     ports:
       - 9200:9200
@@ -583,7 +579,6 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:5.5.2
     container_name: kibana
-    cpus: 0.50
     restart: always
     depends_on:
       - elasticsearch
@@ -679,7 +674,6 @@ services:
   schemaregistry:
     image: ${REPOSITORY}/cp-schema-registry:${CONFLUENT_DOCKER_TAG}
     container_name: schemaregistry
-    cpus: 0.4
     restart: always
     depends_on:
       - kafka1
@@ -740,7 +734,6 @@ services:
     image: ${REPOSITORY}/cp-ksqldb-server:${CONFLUENT_DOCKER_TAG}
     hostname: ksqldb-server
     container_name: ksqldb-server
-    cpus: 0.5
     restart: always
     healthcheck:
       # healthcheck is currently incompatible with RBAC
@@ -836,7 +829,6 @@ services:
   ksqldb-cli:
     image: ${REPOSITORY}/cp-ksqldb-cli:${CONFLUENT_DOCKER_TAG}
     container_name: ksqldb-cli
-    cpus: 0.4
     depends_on:
       - kafka1
       - kafka2
@@ -850,7 +842,6 @@ services:
   restproxy:
     image: ${REPOSITORY}/cp-kafka-rest:${CONFLUENT_DOCKER_TAG}
     restart: always
-    cpus: 0.4
     depends_on:
       - kafka1
       - kafka2
@@ -915,7 +906,6 @@ services:
   streams-demo:
     image: cnfldemos/cp-demo-kstreams:0.0.9
     restart: always
-    cpus: 0.4
     depends_on:
       - kafka1
       - kafka2


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/DEVX-2279

This PR removes the CPU limits on all containers, dramatically improving startup time, and generally improving performance. The results of the following two test runs demonstrate the improvement (note: all containers were pulled prior to testing).

**CPU limited:**

```text
real	14m40.234s
user	5m35.371s
sys	0m22.642s
```

**CPU unlimited:**

```text
real	6m3.344s
user	5m25.884s
sys	0m23.217s
```

It can be seen that the actual CPU time was essentially the same. However the limits placed on CPU allocation in the first test resulted in the total real time being dramatically longer.

## Environment

macOS Catalina 10.15.7 (2.4 GHz 8-core i9, 64GB RAM)
Docker 19.03.13 (limited to 12 CPUs threads and 48GB RAM)

```text
Client:
 Debug Mode: false
 Plugins:
  scan: Docker Scan (Docker Inc., v0.3.4)

Server:
 Containers: 14
  Running: 14
  Paused: 0
  Stopped: 0
 Images: 132
 Server Version: 19.03.13
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Native Overlay Diff: true
 Logging Driver: json-file
 Cgroup Driver: cgroupfs
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 8fba4e9a7d01810a393d5d25a3621dc101981175
 runc version: dc9208a3303feef5b3839f4323d9beb36df0a9dd
 init version: fec3683
 Security Options:
  seccomp
   Profile: default
 Kernel Version: 5.4.39-linuxkit
 Operating System: Docker Desktop
 OSType: linux
 Architecture: x86_64
 CPUs: 12
 Total Memory: 47.07GiB
 Name: docker-desktop
 ID: MUDB:A2BI:3XH5:5PNB:37MB:OXVO:54UJ:SIG7:UCOW:MTSS:LK2U:KYGW
 Docker Root Dir: /var/lib/docker
 Debug Mode: true
  File Descriptors: 158
  Goroutines: 137
  System Time: 2020-11-25T10:48:17.772113099Z
  EventsListeners: 3
 HTTP Proxy: gateway.docker.internal:3128
 HTTPS Proxy: gateway.docker.internal:3129
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false
 Product License: Community Engine
```

[ts_cpu_limited.log](https://github.com/confluentinc/cp-demo/files/5596201/ts_cpu_limited.log)
[ts_cpu_unlimited.log](https://github.com/confluentinc/cp-demo/files/5596202/ts_cpu_unlimited.log)
