### PR TITLE
Added chown appuser for Replicator zip COPY when building in local/SNAPSHOT mode

### DIFF
--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -28,7 +28,7 @@ RUN confluent-hub install --no-prompt cjmatta/kafka-connect-sse:latest
 RUN confluent-hub install --no-prompt jcustenborder/kafka-connect-json-schema:latest
 
 # Install Confluent Replicator connector
-COPY confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip /tmp/confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
+COPY --chown=appuser:appuser confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip /tmp/confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
 RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
 
 # Install Elasticsearch connector


### PR DESCRIPTION
### Description 

When building in local/SNAPSHOT mode on `6.0.x` branch, I got a permissions error, since the container now runs as `appuser` during build, but `COPY` is `root` by-default:

```
 => [4/8] COPY confluentinc-kafka-connect-replicator-6.0.1-SNAPSHOT.zip /tmp/confluentinc-kafka-connect-replicator-6.0.1-SNAPSHOT.zip                                                                                                    0.1s
 => ERROR [5/8] RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-replicator-6.0.1-SNAPSHOT.zip                                                                                                                      1.0s
------
 > [5/8] RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-replicator-6.0.1-SNAPSHOT.zip:
#9 0.648 Running in a "--no-prompt" mode
#9 0.919 Failed to unzip '/tmp/confluentinc-kafka-connect-replicator-6.0.1-SNAPSHOT.zip' into '/tmp/confluent-hub-tmp1836100834509112553'
#9 0.919 /tmp/confluentinc-kafka-connect-replicator-6.0.1-SNAPSHOT.zip (Permission denied)
#9 0.919
#9 0.919 Error: Unknown error
```

This change will copy the Replicator connector archive in as appuser:appuser so it can be read/accessed and installed by that user.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

[ ] Documentation
[X] Run cp-demo
[ ] jmx-monitoring-stacks


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
