### PR TITLE
Doc: updated min Docker Compose version to 1.16.0 (was 1.14.0)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,7 +57,7 @@ Prerequisites
 This example has been validated with:
 
 -  Docker version 17.06.1-ce
--  Docker Compose version 1.14.0 with Docker Compose file format 2.3
+-  Docker Compose version 1.16.0 with Docker Compose file format 2.3
 -  Java version 1.8.0_92
 -  MacOS 10.15.3 (note for `Ubuntu environments <https://github.com/confluentinc/cp-demo/issues/53>`__)
 -  OpenSSL 1.1.1d


### PR DESCRIPTION
1.16.0 is the minimum version for compose file version 2.3.  [RBAC](https://github.com/confluentinc/cp-demo/pull/164/files#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R57) bumped the Docker Compose file version to 2.3, which requires min 1.16.0.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

cp-demo 6.0.0-post branch will launch with Docker Compose 1.16.0.

- [x] Documentation
- [x] Run cp-demo

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
