### PR TITLE
DEVX-2297: cp-demo 6.0 doesn't start when run from in side the script…

### DIFF
--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -104,21 +104,23 @@ build_connect_image()
 {
   echo
   echo "Building custom Docker image with Connect version ${CONFLUENT_DOCKER_TAG} and connector version ${CONNECTOR_VERSION}"
+
+  local DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
   
   if [[ "${CONNECTOR_VERSION}" =~ "SNAPSHOT" ]]; then
-    DOCKERFILE="${DIR}/../Dockerfile-local"
+    DOCKERFILE="${DIR}/../../Dockerfile-local"
   else
-    DOCKERFILE=$"{DIR}/../Dockerfile-confluenthub"
+    DOCKERFILE="${DIR}/../../Dockerfile-confluenthub"
   fi
-  echo "docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f $DOCKERFILE ."
-  docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f $DOCKERFILE . || {
+  echo "docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f $DOCKERFILE ${DIR}/../../."
+  docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f $DOCKERFILE ${DIR}/../../. || {
     echo "ERROR: Docker image build failed. Please troubleshoot and try again. For troubleshooting instructions see https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html#troubleshooting"
     exit 1
   }
   
   # Copy the updated kafka.connect.truststore.jks back to the host
   docker create --name cp-demo-tmp-connect localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION}
-  docker cp cp-demo-tmp-connect:/tmp/kafka.connect.truststore.jks ${DIR}/security/kafka.connect.truststore.jks
+  docker cp cp-demo-tmp-connect:/tmp/kafka.connect.truststore.jks ${DIR}/../security/kafka.connect.truststore.jks
   docker rm cp-demo-tmp-connect
 }
 


### PR DESCRIPTION
…s folder

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2297

_What behavior does this PR change, and why?_

This bug was introduced when the connect image build was moved into the functions library, out of the main start script: https://github.com/confluentinc/cp-demo/commit/edd165be8f8eabcda8088127003d46f2231704a8

The fix enables users to run `./scripts/start.sh` or `cd scripts ... ./start.sh`

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->
