### PR TITLE
DEVX-2277: Change topic creation to use Confluent Server v3 REST API

### DIFF
--- a/scripts/helper/create-topics.sh
+++ b/scripts/helper/create-topics.sh
@@ -4,44 +4,46 @@ IFS=$'\n\t'
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-KAFKA_CLUSTER_ID=$(curl --insecure --location --request GET 'https://localhost:8091/kafka/v3/clusters' --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' | jq -r '.data[0].cluster_id')
+KAFKA_CLUSTER_ID=$(curl -s --insecure --location --request GET 'https://localhost:8091/kafka/v3/clusters' --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' | jq -r '.data[0].cluster_id')
 
-curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+echo "cluster_id: ${KAFKA_CLUSTER_ID}"
+
+curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-binary @<(jq -n --arg topic_name users --arg confluent_value_schema_validation "true" -f ${DIR}/topic.jq)
+--data-binary @<(jq -n --arg topic_name users --arg confluent_value_schema_validation "true" -f ${DIR}/topic.jq) | jq
 
-curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-binary @<(jq -n --arg topic_name "wikipedia.parsed" --arg confluent_value_schema_validation "true" -f ${DIR}/topic.jq)
+--data-binary @<(jq -n --arg topic_name "wikipedia.parsed" --arg confluent_value_schema_validation "true" -f ${DIR}/topic.jq) | jq
 
-curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-binary @<(jq -n --arg topic_name "wikipedia.parsed.count-by-domain" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
+--data-binary @<(jq -n --arg topic_name "wikipedia.parsed.count-by-domain" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
 
-curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-binary @<(jq -n --arg topic_name "wikipedia.failed" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
+--data-binary @<(jq -n --arg topic_name "wikipedia.failed" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
 
-curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-binary @<(jq -n --arg topic_name "WIKIPEDIABOT" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
+--data-binary @<(jq -n --arg topic_name "WIKIPEDIABOT" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
 
-curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-binary @<(jq -n --arg topic_name "WIKIPEDIANOBOT" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
+--data-binary @<(jq -n --arg topic_name "WIKIPEDIANOBOT" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
 
-curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-binary @<(jq -n --arg topic_name "EN_WIKIPEDIA_GT_1" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
+--data-binary @<(jq -n --arg topic_name "EN_WIKIPEDIA_GT_1" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
 
-curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-binary @<(jq -n --arg topic_name "EN_WIKIPEDIA_GT_1_COUNTS" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
+--data-binary @<(jq -n --arg topic_name "EN_WIKIPEDIA_GT_1_COUNTS" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq

--- a/scripts/helper/create-topics.sh
+++ b/scripts/helper/create-topics.sh
@@ -8,42 +8,44 @@ KAFKA_CLUSTER_ID=$(curl -s --insecure --location --request GET 'https://localhos
 
 echo "cluster_id: ${KAFKA_CLUSTER_ID}"
 
+user="superUser:superUser"
+
 curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--user $user \
 --header 'Content-Type: application/json' \
---header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
 --data-binary @<(jq -n --arg topic_name users --arg confluent_value_schema_validation "true" -f ${DIR}/topic.jq) | jq
 
 curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--user $user \
 --header 'Content-Type: application/json' \
---header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
 --data-binary @<(jq -n --arg topic_name "wikipedia.parsed" --arg confluent_value_schema_validation "true" -f ${DIR}/topic.jq) | jq
 
 curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--user $user \
 --header 'Content-Type: application/json' \
---header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
 --data-binary @<(jq -n --arg topic_name "wikipedia.parsed.count-by-domain" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
 
 curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--user $user \
 --header 'Content-Type: application/json' \
---header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
 --data-binary @<(jq -n --arg topic_name "wikipedia.failed" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
 
 curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--user $user \
 --header 'Content-Type: application/json' \
---header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
 --data-binary @<(jq -n --arg topic_name "WIKIPEDIABOT" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
 
 curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--user $user \
 --header 'Content-Type: application/json' \
---header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
 --data-binary @<(jq -n --arg topic_name "WIKIPEDIANOBOT" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
 
 curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--user $user \
 --header 'Content-Type: application/json' \
---header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
 --data-binary @<(jq -n --arg topic_name "EN_WIKIPEDIA_GT_1" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
 
 curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--user $user \
 --header 'Content-Type: application/json' \
---header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
 --data-binary @<(jq -n --arg topic_name "EN_WIKIPEDIA_GT_1_COUNTS" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq

--- a/scripts/helper/create-topics.sh
+++ b/scripts/helper/create-topics.sh
@@ -2,88 +2,46 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
 KAFKA_CLUSTER_ID=$(curl --insecure --location --request GET 'https://localhost:8091/kafka/v3/clusters' --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' | jq -r '.data[0].cluster_id')
 
 curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-raw '{
-    "topic_name": "users",
-    "partitions_count": 2,
-    "replication_factor": 2,
-    "configs": [
-        {
-            "name": "confluent.value.schema.validation",
-            "value": "true"
-        }
-    ]
-}'
+--data-binary @<(jq -n --arg topic_name users --arg confluent_value_schema_validation "true" -f ${DIR}/topic.jq)
 
 curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-raw '{
-    "topic_name": "wikipedia.parsed",
-    "partitions_count": 2,
-    "replication_factor": 2,
-    "configs": [
-        {
-            "name": "confluent.value.schema.validation",
-            "value": "true"
-        }
-    ]
-}'
+--data-binary @<(jq -n --arg topic_name "wikipedia.parsed" --arg confluent_value_schema_validation "true" -f ${DIR}/topic.jq)
 
 curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-raw '{
-    "topic_name": "wikipedia.parsed.count-by-domain",
-    "partitions_count": 2,
-    "replication_factor": 2
-}'
+--data-binary @<(jq -n --arg topic_name "wikipedia.parsed.count-by-domain" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
 
 curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-raw '{
-    "topic_name": "wikipedia.failed",
-    "partitions_count": 2,
-    "replication_factor": 2
-}'
+--data-binary @<(jq -n --arg topic_name "wikipedia.failed" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
 
 curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-raw '{
-    "topic_name": "WIKIPEDIABOT",
-    "partitions_count": 2,
-    "replication_factor": 2
-}'
+--data-binary @<(jq -n --arg topic_name "WIKIPEDIABOT" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
 
 curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-raw '{
-    "topic_name": "WIKIPEDIANOBOT",
-    "partitions_count": 2,
-    "replication_factor": 2
-}'
+--data-binary @<(jq -n --arg topic_name "WIKIPEDIANOBOT" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
 
 curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-raw '{
-    "topic_name": "EN_WIKIPEDIA_GT_1",
-    "partitions_count": 2,
-    "replication_factor": 2
-}'
+--data-binary @<(jq -n --arg topic_name "EN_WIKIPEDIA_GT_1" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)
 
 curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
---data-raw '{
-    "topic_name": "EN_WIKIPEDIA_GT_1_COUNTS",
-    "partitions_count": 2,
-    "replication_factor": 2
-}'
+--data-binary @<(jq -n --arg topic_name "EN_WIKIPEDIA_GT_1_COUNTS" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq)

--- a/scripts/helper/create-topics.sh
+++ b/scripts/helper/create-topics.sh
@@ -1,47 +1,89 @@
 #!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
 
-# Create Kafka topic users, using appSA principal
-export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/appSA.config \
-   --topic users \
-   --create \
-   --replication-factor 2 \
-   --partitions 2 \
-   --config confluent.value.schema.validation=true
+KAFKA_CLUSTER_ID=$(curl --insecure --location --request GET 'https://localhost:8091/kafka/v3/clusters' --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' | jq -r '.data[0].cluster_id')
 
-# Create Kafka topics with prefix wikipedia, using connectorSA principal
-export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
-   --topic wikipedia.parsed \
-   --create \
-   --replication-factor 2 \
-   --partitions 2 \
-   --config confluent.value.schema.validation=true
-export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
-   --topic wikipedia.parsed.count-by-domain \
-   --create \
-   --replication-factor 2 \
-   --partitions 2
-export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-   --bootstrap-server kafka1:11091 \
-   --command-config /etc/kafka/secrets/connectorSA_without_interceptors_ssl.config \
-   --topic wikipedia.failed \
-   --create \
-   --replication-factor 2 \
-   --partitions 2
+curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
+--data-raw '{
+    "topic_name": "users",
+    "partitions_count": 2,
+    "replication_factor": 2,
+    "configs": [
+        {
+            "name": "confluent.value.schema.validation",
+            "value": "true"
+        }
+    ]
+}'
 
-# Create Kafka topics with prefix WIKIPEDIA or EN_WIKIPEDIA, using ksqlDBUser principal
-for t in WIKIPEDIABOT WIKIPEDIANOBOT EN_WIKIPEDIA_GT_1 EN_WIKIPEDIA_GT_1_COUNTS
-do
-  export KAFKA_LOG4J_OPTS="-Dlog4j.rootLogger=DEBUG,stdout -Dlog4j.logger.kafka=DEBUG,stdout" && kafka-topics \
-     --bootstrap-server kafka1:11091 \
-     --command-config /etc/kafka/secrets/ksqlDBUser_without_interceptors_ssl.config \
-     --topic "$t" \
-     --create \
-     --replication-factor 2 \
-     --partitions 2
-done
+curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
+--data-raw '{
+    "topic_name": "wikipedia.parsed",
+    "partitions_count": 2,
+    "replication_factor": 2,
+    "configs": [
+        {
+            "name": "confluent.value.schema.validation",
+            "value": "true"
+        }
+    ]
+}'
+
+curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
+--data-raw '{
+    "topic_name": "wikipedia.parsed.count-by-domain",
+    "partitions_count": 2,
+    "replication_factor": 2
+}'
+
+curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
+--data-raw '{
+    "topic_name": "wikipedia.failed",
+    "partitions_count": 2,
+    "replication_factor": 2
+}'
+
+curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
+--data-raw '{
+    "topic_name": "WIKIPEDIABOT",
+    "partitions_count": 2,
+    "replication_factor": 2
+}'
+
+curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
+--data-raw '{
+    "topic_name": "WIKIPEDIANOBOT",
+    "partitions_count": 2,
+    "replication_factor": 2
+}'
+
+curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
+--data-raw '{
+    "topic_name": "EN_WIKIPEDIA_GT_1",
+    "partitions_count": 2,
+    "replication_factor": 2
+}'
+
+curl --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' \
+--data-raw '{
+    "topic_name": "EN_WIKIPEDIA_GT_1_COUNTS",
+    "partitions_count": 2,
+    "replication_factor": 2
+}'

--- a/scripts/helper/create-topics.sh
+++ b/scripts/helper/create-topics.sh
@@ -3,49 +3,19 @@ set -euo pipefail
 IFS=$'\n\t'
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+source ${DIR}/functions.sh
 
 KAFKA_CLUSTER_ID=$(curl -s --insecure --location --request GET 'https://localhost:8091/kafka/v3/clusters' --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' | jq -r '.data[0].cluster_id')
 
 echo "cluster_id: ${KAFKA_CLUSTER_ID}"
 
-user="superUser:superUser"
+auth="superUser:superUser"
 
-curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
---user $user \
---header 'Content-Type: application/json' \
---data-binary @<(jq -n --arg topic_name users --arg confluent_value_schema_validation "true" -f ${DIR}/topic.jq) | jq
-
-curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
---user $user \
---header 'Content-Type: application/json' \
---data-binary @<(jq -n --arg topic_name "wikipedia.parsed" --arg confluent_value_schema_validation "true" -f ${DIR}/topic.jq) | jq
-
-curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
---user $user \
---header 'Content-Type: application/json' \
---data-binary @<(jq -n --arg topic_name "wikipedia.parsed.count-by-domain" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
-
-curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
---user $user \
---header 'Content-Type: application/json' \
---data-binary @<(jq -n --arg topic_name "wikipedia.failed" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
-
-curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
---user $user \
---header 'Content-Type: application/json' \
---data-binary @<(jq -n --arg topic_name "WIKIPEDIABOT" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
-
-curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
---user $user \
---header 'Content-Type: application/json' \
---data-binary @<(jq -n --arg topic_name "WIKIPEDIANOBOT" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
-
-curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
---user $user \
---header 'Content-Type: application/json' \
---data-binary @<(jq -n --arg topic_name "EN_WIKIPEDIA_GT_1" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
-
-curl -s --insecure --location --request POST "https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics" \
---user $user \
---header 'Content-Type: application/json' \
---data-binary @<(jq -n --arg topic_name "EN_WIKIPEDIA_GT_1_COUNTS" --arg confluent_value_schema_validation "false" -f ${DIR}/topic.jq) | jq
+create_topic localhost:8091 ${KAFKA_CLUSTER_ID} users true ${auth}
+create_topic localhost:8091 ${KAFKA_CLUSTER_ID} wikipedia.parsed true ${auth}
+create_topic localhost:8091 ${KAFKA_CLUSTER_ID} wikipedia.parsed.count-by-domain false ${auth}
+create_topic localhost:8091 ${KAFKA_CLUSTER_ID} wikipedia.failed false ${auth}
+create_topic localhost:8091 ${KAFKA_CLUSTER_ID} WIKIPEDIABOT false ${auth}
+create_topic localhost:8091 ${KAFKA_CLUSTER_ID} WIKIPEDIANOBOT false ${auth}
+create_topic localhost:8091 ${KAFKA_CLUSTER_ID} EN_WIKIPEDIA_GT_1 false ${auth}
+create_topic localhost:8091 ${KAFKA_CLUSTER_ID} EN_WIKIPEDIA_GT_1_COUNTS false ${auth}

--- a/scripts/helper/create-topics.sh
+++ b/scripts/helper/create-topics.sh
@@ -5,17 +5,16 @@ IFS=$'\n\t'
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/functions.sh
 
-KAFKA_CLUSTER_ID=$(curl -s --insecure --location --request GET 'https://localhost:8091/kafka/v3/clusters' --header 'Authorization: Basic c3VwZXJVc2VyOnN1cGVyVXNlcg==' | jq -r '.data[0].cluster_id')
-
-echo "cluster_id: ${KAFKA_CLUSTER_ID}"
+KAFKA_CLUSTER_ID=$(get_kafka_cluster_id_from_container)
+echo "KAFKA_CLUSTER_ID: ${KAFKA_CLUSTER_ID}"
 
 auth="superUser:superUser"
 
-create_topic localhost:8091 ${KAFKA_CLUSTER_ID} users true ${auth}
-create_topic localhost:8091 ${KAFKA_CLUSTER_ID} wikipedia.parsed true ${auth}
-create_topic localhost:8091 ${KAFKA_CLUSTER_ID} wikipedia.parsed.count-by-domain false ${auth}
-create_topic localhost:8091 ${KAFKA_CLUSTER_ID} wikipedia.failed false ${auth}
-create_topic localhost:8091 ${KAFKA_CLUSTER_ID} WIKIPEDIABOT false ${auth}
-create_topic localhost:8091 ${KAFKA_CLUSTER_ID} WIKIPEDIANOBOT false ${auth}
-create_topic localhost:8091 ${KAFKA_CLUSTER_ID} EN_WIKIPEDIA_GT_1 false ${auth}
-create_topic localhost:8091 ${KAFKA_CLUSTER_ID} EN_WIKIPEDIA_GT_1_COUNTS false ${auth}
+create_topic kafka1:8091 ${KAFKA_CLUSTER_ID} users true ${auth}
+create_topic kafka1:8091 ${KAFKA_CLUSTER_ID} wikipedia.parsed true ${auth}
+create_topic kafka1:8091 ${KAFKA_CLUSTER_ID} wikipedia.parsed.count-by-domain false ${auth}
+create_topic kafka1:8091 ${KAFKA_CLUSTER_ID} wikipedia.failed false ${auth}
+create_topic kafka1:8091 ${KAFKA_CLUSTER_ID} WIKIPEDIABOT false ${auth}
+create_topic kafka1:8091 ${KAFKA_CLUSTER_ID} WIKIPEDIANOBOT false ${auth}
+create_topic kafka1:8091 ${KAFKA_CLUSTER_ID} EN_WIKIPEDIA_GT_1 false ${auth}
+create_topic kafka1:8091 ${KAFKA_CLUSTER_ID} EN_WIKIPEDIA_GT_1_COUNTS false ${auth}

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -35,7 +35,7 @@ verify_installed()
 preflight_checks()
 {
   # Verify appropriate tools are installed on host
-  for cmd in jq docker-compose keytool docker openssl xargs awk; do
+  for cmd in curl jq docker-compose keytool docker openssl xargs awk; do
     verify_installed $cmd || exit 1
   done
 

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -287,7 +287,7 @@ create_topic() {
   echo "response code: " $http_code
   echo $out| jq || true
 
-  if [[ $status -ne 0 || http_code -gt 299 || -z $out || $out =~ "error_code" ]]; then
+  if [[ $status -ne 0 || $http_code -gt 299 || -z $out || $out =~ "error_code" ]]; then
     echo "ERROR: create topic failed $out"
     return 1
   fi

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -257,3 +257,26 @@ END
     exit 1
   fi
 }
+
+create_topic() {
+  broker_host_port=$1
+  cluster_id=$2
+  topic_name=$3
+  confluent_value_schema_validation=$4
+  auth=$5
+
+  RESULT=$(curl -sS --insecure -X POST \
+    -u ${auth} \
+    --header 'Content-Type: application/json' \
+    --data-binary @<(jq -n --arg topic_name "${topic_name}" --arg confluent_value_schema_validation "${confluent_value_schema_validation}" -f ${DIR}/topic.jq) \
+    "https://${broker_host_port}/kafka/v3/clusters/${cluster_id}/topics") && RC=$? || RC=$?
+
+  echo $RESULT | jq || true
+
+  if [[ $RC -ne 0 || -z $RESULT || $RESULT =~ "error_code" ]]; then
+    echo "ERROR: create topic failed $RESULT"
+    return 1
+  fi
+
+  return 0
+}

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -272,6 +272,7 @@ create_topic() {
     -u ${auth} \
     --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
     --header 'Content-Type: application/json' \
+    --header 'Accept: application/json' \
     --data-binary @<(jq -n --arg topic_name "${topic_name}" --arg confluent_value_schema_validation "${confluent_value_schema_validation}" -f ${DIR}/topic.jq) \
     "https://${broker_host_port}/kafka/v3/clusters/${cluster_id}/topics") && RC=$? || RC=$?
 

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -259,6 +259,9 @@ END
 }
 
 create_topic() {
+
+  local DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
   broker_host_port=$1
   cluster_id=$2
   topic_name=$3
@@ -267,7 +270,7 @@ create_topic() {
 
   RESULT=$(curl -sS -X POST \
     -u ${auth} \
-    --cacert ${DIR}/../security/snakeoil-ca-1.crt \
+    --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
     --header 'Content-Type: application/json' \
     --data-binary @<(jq -n --arg topic_name "${topic_name}" --arg confluent_value_schema_validation "${confluent_value_schema_validation}" -f ${DIR}/topic.jq) \
     "https://${broker_host_port}/kafka/v3/clusters/${cluster_id}/topics") && RC=$? || RC=$?

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -268,8 +268,10 @@ create_topic() {
   confluent_value_schema_validation=$4
   auth=$5
 
+  # note --tlsv1.2 below sets the _minimum_ allowed TLS version - expect TLS 1.3 to be negotiated here
   RESULT=$(curl -sS -X POST \
     -u ${auth} \
+    --tlsv1.2 \
     --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
     --header 'Content-Type: application/json' \
     --header 'Accept: application/json' \

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -269,19 +269,26 @@ create_topic() {
   auth=$5
 
   # note --tlsv1.2 below sets the _minimum_ allowed TLS version - expect TLS 1.3 to be negotiated here
-  RESULT=$(curl -sS -X POST \
+  {
+  IFS= read -rd '' out
+  IFS= read -rd '' http_code
+  IFS= read -rd '' status
+  } < <({ out=$(curl -sS -X POST \
+    -o /dev/stderr \
+    -w "%{http_code}" \
     -u ${auth} \
     --tlsv1.2 \
     --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
     --header 'Content-Type: application/json' \
     --header 'Accept: application/json' \
     --data-binary @<(jq -n --arg topic_name "${topic_name}" --arg confluent_value_schema_validation "${confluent_value_schema_validation}" -f ${DIR}/topic.jq) \
-    "https://${broker_host_port}/kafka/v3/clusters/${cluster_id}/topics") && RC=$? || RC=$?
+    "https://${broker_host_port}/kafka/v3/clusters/${cluster_id}/topics"); } 2>&1; printf '\0%s' "$out" "$?") || true
 
-  echo $RESULT | jq || true
+  echo "response code: " $http_code
+  echo $out| jq || true
 
-  if [[ $RC -ne 0 || -z $RESULT || $RESULT =~ "error_code" ]]; then
-    echo "ERROR: create topic failed $RESULT"
+  if [[ $status -ne 0 || http_code -gt 299 || -z $out || $out =~ "error_code" ]]; then
+    echo "ERROR: create topic failed $out"
     return 1
   fi
 

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -265,8 +265,9 @@ create_topic() {
   confluent_value_schema_validation=$4
   auth=$5
 
-  RESULT=$(curl -sS --insecure -X POST \
+  RESULT=$(curl -sS -X POST \
     -u ${auth} \
+    --cacert ${DIR}/../security/snakeoil-ca-1.crt \
     --header 'Content-Type: application/json' \
     --data-binary @<(jq -n --arg topic_name "${topic_name}" --arg confluent_value_schema_validation "${confluent_value_schema_validation}" -f ${DIR}/topic.jq) \
     "https://${broker_host_port}/kafka/v3/clusters/${cluster_id}/topics") && RC=$? || RC=$?

--- a/scripts/helper/topic.jq
+++ b/scripts/helper/topic.jq
@@ -1,0 +1,11 @@
+{
+    "topic_name": $topic_name,
+    "partitions_count": 2,
+    "replication_factor": 2,
+    "configs": [
+        {
+            "name": "confluent.value.schema.validation",
+            "value": $confluent_value_schema_validation
+        }
+    ]
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -77,7 +77,7 @@ docker-compose up -d schemaregistry connect control-center
 
 echo
 echo -e "Create topics in Kafka cluster:"
-docker-compose exec kafka1 bash -c "/tmp/helper/create-topics.sh" || exit 1
+${DIR}/helper/create-topics.sh || exit 1
 
 # Verify Confluent Control Center has started
 MAX_WAIT=300

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -77,7 +77,7 @@ docker-compose up -d schemaregistry connect control-center
 
 echo
 echo -e "Create topics in Kafka cluster:"
-${DIR}/helper/create-topics.sh || exit 1
+docker-compose exec tools bash -c "/tmp/helper/create-topics.sh" || exit 1
 
 # Verify Confluent Control Center has started
 MAX_WAIT=300


### PR DESCRIPTION
### Description 

_What behavior does this PR change, and why?_

I was using the v3 REST API with `cp-demo` and figured changing topic-creation to use the v3 REST API would be a good addition.  This PR retires shelling-in to a container to run CLI tool `kafka-topics`, replacing with `POST` calls to https://localhost:8091/kafka/v3/clusters/${KAFKA_CLUSTER_ID}/topics .

This appears to be much faster, and would eliminate the need for efforts to parallelise topic-creation per #285 .

`curl` was missing from pre-flight installed checks, so added that too.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation
- [X] Run cp-demo
- [ ] jmx-monitoring-stacks


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

Some questions for reviewer:

- Currently we don't bother to use the same user principal to create the topics as before - they are all created by `superUser`.  Does it matter which user creates the topic?
- Note currently sending `Authorization: Basic` and the base64 credentials - would `curl -u` / `--user` be preferred?

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
