### PR TITLE
DEVX-2311: cp-demo cannot detect pre-GA code with "-SNAPSHOT"

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -9,8 +9,7 @@ source ${DIR}/../env_files/config.env
 # The '/' which separates the REPOSITORY from the image name is not required here
 export REPOSITORY=${REPOSITORY:-confluentinc}
 
-# If CONNECTOR_VERSION ~ `x.x.x-0` then this is pre-GA and cp-demo uses Dockerfile-local
-# and expects user to build and provide a local file confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
+# CONNECTOR_VERSION - connector version
 export CONNECTOR_VERSION=${CONNECTOR_VERSION:-$CONFLUENT}
 
 # Control Center and ksqlDB server must both be HTTP or both be HTTPS; mixed modes are not supported

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -9,7 +9,7 @@ source ${DIR}/../env_files/config.env
 # The '/' which separates the REPOSITORY from the image name is not required here
 export REPOSITORY=${REPOSITORY:-confluentinc}
 
-# If CONNECTOR_VERSION ~ `SNAPSHOT` then cp-demo uses Dockerfile-local
+# If CONNECTOR_VERSION ~ `x.x.x-0` then this is pre-GA and cp-demo uses Dockerfile-local
 # and expects user to build and provide a local file confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
 export CONNECTOR_VERSION=${CONNECTOR_VERSION:-$CONFLUENT}
 

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -107,7 +107,8 @@ build_connect_image()
 
   local DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
   
-  if [[ "${CONNECTOR_VERSION}" =~ "SNAPSHOT" ]]; then
+  # If CONNECTOR_VERSION ~ `x.x.x-0` then this is pre-GA and cp-demo uses Dockerfile-local
+  if [[ "${CONNECTOR_VERSION}" =~ "-0" ]]; then
     DOCKERFILE="${DIR}/../../Dockerfile-local"
   else
     DOCKERFILE="${DIR}/../../Dockerfile-confluenthub"

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -107,11 +107,12 @@ build_connect_image()
 
   local DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
   
-  # If CONNECTOR_VERSION ~ `x.x.x-0` then this is pre-GA and cp-demo uses Dockerfile-local
-  if [[ "${CONNECTOR_VERSION}" =~ "-0" ]]; then
-    DOCKERFILE="${DIR}/../../Dockerfile-local"
-  else
+  # If post-GA: cp-demo uses Dockerfile-confluenthub
+  # If pre-GA: cp-demo uses Dockerfile-local, user provides confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
+  if [[ "$CONFLUENT_RELEASE_TAG_OR_BRANCH" =~ "-post" ]]; then
     DOCKERFILE="${DIR}/../../Dockerfile-confluenthub"
+  else
+    DOCKERFILE="${DIR}/../../Dockerfile-local"
   fi
   echo "docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f $DOCKERFILE ${DIR}/../../."
   docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f $DOCKERFILE ${DIR}/../../. || {

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -2,14 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../env_files/config.env
-
-# REPOSITORY - repository (probably) for Docker images
-# The '/' which separates the REPOSITORY from the image name is not required here
-export REPOSITORY=${REPOSITORY:-confluentinc}
-
-# If CONNECTOR_VERSION ~ `SNAPSHOT` then cp-demo uses Dockerfile-local
-# and expects user to build and provide a local file confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
-export CONNECTOR_VERSION=${CONNECTOR_VERSION:-$CONFLUENT}
+source ${DIR}/env.sh
 
 docker-compose down --volumes
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2311

_What behavior does this PR change, and why?_

Change pattern match to detect pre-GA

Note: cp-demo still doesn't run on 6.1.x due to `io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension` error

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] Run cp-demo (up to `io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension` error)
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
