### PR TITLE
DEVX-2339: Elasticsearch v11.0.0 does not work in cp-demo; roll back …

### DIFF
--- a/Dockerfile-confluenthub
+++ b/Dockerfile-confluenthub
@@ -31,7 +31,7 @@ RUN confluent-hub install --no-prompt jcustenborder/kafka-connect-json-schema:la
 RUN confluent-hub install --no-prompt confluentinc/kafka-connect-replicator:${CONNECTOR_VERSION}
 
 # Install Elasticsearch connector
-RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:latest
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
 
 # Add JDK default cacerts to kafka.connect.truststore.jks to allow outgoing HTTPS
 COPY scripts/security/kafka.connect.truststore.jks /tmp/kafka.connect.truststore.jks

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -32,7 +32,7 @@ COPY confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip /tmp/conflue
 RUN confluent-hub install --no-prompt /tmp/confluentinc-kafka-connect-replicator-${CONNECTOR_VERSION}.zip
 
 # Install Elasticsearch connector
-RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:latest
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:10.0.2
 
 # Add JDK default cacerts to kafka.connect.truststore.jks to allow outgoing HTTPS
 COPY scripts/security/kafka.connect.truststore.jks /tmp/kafka.connect.truststore.jks


### PR DESCRIPTION
…to v10.0.2

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2339

_What behavior does this PR change, and why?_

elasticsearch sink connector v11.0.0 not compatible with cp-demo (under investigation).  In the meanwhile, pin to v10.0.2


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
