### PR TITLE
Adds CORS properties to ksqlDB allowing access via Control Center

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -777,6 +777,12 @@ services:
       KSQL_BOOTSTRAP_SERVERS: kafka1:10091,kafka2:10092
       KSQL_HOST_NAME: ksqldb-server
       KSQL_LISTENERS: "http://0.0.0.0:8088,https://0.0.0.0:8089"
+
+      # KSQL-5795 / MMA-9429 - CORS properties required for Control Center -> ksqlDB access
+      KSQL_ACCESS_CONTROL_ALLOW_ORIGIN: "*"
+      KSQL_ACCESS_CONTROL_ALLOW_METHODS: "GET,POST,HEAD"
+      KSQL_ACCESS_CONTROL_ALLOW_HEADERS: "X-Requested-With,Content-Type,Accept,Origin,Authorization"
+
       KSQL_CACHE_MAX_BYTES_BUFFERING: 0
       
       KSQL_KSQL_SECURITY_EXTENSION_CLASS: io.confluent.ksql.security.KsqlConfluentSecurityExtension


### PR DESCRIPTION
### Description 

_What behavior does this PR change, and why?_

Adds CORS properties required in ksqlDB Server configuration to allow it to be accessed via Control Center on a different server.

Prior to this change, accessing ksqlDB page in Control Center for CP 6.1.x branch will result in 401 UNAUTHORIZED for requests to `/ksql`.  With these properties set, the `wikipedia` application is no longer deactivated in the UI and can be clicked/accessed.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation
- [X] Run cp-demo
- [ ] jmx-monitoring-stacks


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
