### PR TITLE
DEVX-2340: Enable Elasticsearch health status show green

### DIFF
--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -167,10 +167,14 @@ build_viz()
   echo
   echo -e "\nWaiting up to $MAX_WAIT seconds for Elasticsearch to be ready"
   retry $MAX_WAIT host_check_elasticsearch_ready || exit 1
+
   echo -e "\nProvide data mapping to Elasticsearch:"
   ${DIR}/../dashboard/set_elasticsearch_mapping_bot.sh
   ${DIR}/../dashboard/set_elasticsearch_mapping_count.sh
   echo
+
+  # Enable Elasticsearch health status (http://localhost:9200/_cluster/health) show green
+  curl -X PUT "localhost:9200/wikipediabot/_settings?pretty" -H 'Content-Type: application/json' -d' { "number_of_replicas": 0 }'
 
   echo -e "\nStart streaming to Elasticsearch sink connector:"
   ${DIR}/../connectors/submit_elastic_sink_config.sh

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -173,9 +173,6 @@ build_viz()
   ${DIR}/../dashboard/set_elasticsearch_mapping_count.sh
   echo
 
-  # Enable Elasticsearch health status (http://localhost:9200/_cluster/health) show green
-  curl -X PUT "localhost:9200/wikipediabot/_settings?pretty" -H 'Content-Type: application/json' -d' { "number_of_replicas": 0 }'
-
   echo -e "\nStart streaming to Elasticsearch sink connector:"
   ${DIR}/../connectors/submit_elastic_sink_config.sh
   echo
@@ -188,6 +185,9 @@ build_viz()
   echo -e "\nConfigure Kibana dashboard:"
   ${DIR}/../dashboard/configure_kibana_dashboard.sh
   echo
+
+  # Enable Elasticsearch health status (http://localhost:9200/_cluster/health) show green
+  curl -X PUT "localhost:9200/wikipediabot/_settings?pretty" -H 'Content-Type: application/json' -d' { "number_of_replicas": 0 }'
 
   return 0
 }


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2340

_What behavior does this PR change, and why?_

Elasticsearch health status: `curl  -X GET http://localhost:9200/_cluster/health | jq .status`

Without PR: health is yellow
With PR: health is green

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->
