### PR TITLE
DEVX-2204: cp-demo: Update kstreams app jib timestamp usage

### DIFF
--- a/kstreams-app/build.gradle
+++ b/kstreams-app/build.gradle
@@ -73,7 +73,7 @@ jib {
   to.image = "cnfldemos/cp-demo-kstreams:${version}"
   container {
     entrypoint = '/app/start.sh'
-    useCurrentTimestamp=true
+    creationTime = 'USE_CURRENT_TIMESTAMP'
   }
   extraDirectories {
     permissions = [


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2204

_What behavior does this PR change, and why?_

Address:

```
> Task :jibDockerBuild
'jib.container.useCurrentTimestamp' is deprecated; use 'jib.container.creationTime' with the value 'USE_CURRENT_TIMESTAMP' instead
Setting image creation time to current time; your image may not be reproducible.
```


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
- [x] `make package`

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
- [ ] `make package`
