### PR TITLE
DEVX-2235: Use explicit connector version numbers in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ FROM $REPOSITORY/cp-enterprise-replicator:$CP_VERSION
 ENV CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
 
 # Install SSE connector
-RUN confluent-hub install --no-prompt cjmatta/kafka-connect-sse:latest
+RUN confluent-hub install --no-prompt cjmatta/kafka-connect-sse:1.0
 
 # Install FromJson transformation
-RUN confluent-hub install --no-prompt jcustenborder/kafka-connect-json-schema:latest
+RUN confluent-hub install --no-prompt jcustenborder/kafka-connect-json-schema:0.2.5
 
 # Install Elasticsearch connector
 RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:11.0.0


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2235

_What behavior does this PR change, and why?_

To avoid a pint merge and given the changes to the Dockerfiles between `6.0.1-post` and `6.1.x`, I am suggesting to merge this branch into `6.1.x`. 

Given that we have been using the latest connector versions, I propose we pin to what those latest versions are. I validated my change by running cp-demo with the pinned versions.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
 - [x] Documentation --> documentation doesn't appear that it would need to change
 - [x] Run cp-demo 
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
 - [ ] Run cp-demo 
<!-- - [ ] jmx-monitoring-stacks -->
