### PR TITLE
DEVX-2432: add topic.config.sync

### DIFF
--- a/scripts/connectors/submit_replicator_to_ccloud_config.sh
+++ b/scripts/connectors/submit_replicator_to_ccloud_config.sh
@@ -57,7 +57,6 @@ DATA=$( cat << EOF
     "src.kafka.timestamps.producer.confluent.monitoring.interceptor.sasl.login.callback.handler.class": "io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler",
     "src.kafka.timestamps.producer.confluent.monitoring.interceptor.sasl.jaas.config": "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required username=\"connectorSA\" password=\"connectorSA\" metadataServerUrls=\"https://kafka1:8091,https://kafka2:8092\";",
     "src.kafka.timestamps.producer.confluent.monitoring.interceptor.sasl.mechanism": "OAUTHBEARER",
-
     "producer.override.interceptor.classes": "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor",
     "producer.override.confluent.monitoring.interceptor.security.protocol": "SASL_SSL",
     "producer.override.confluent.monitoring.interceptor.bootstrap.servers": "kafka1:10091",
@@ -82,6 +81,7 @@ DATA=$( cat << EOF
     "src.consumer.confluent.monitoring.interceptor.sasl.mechanism": "OAUTHBEARER",
     "src.consumer.group.id": "connect-replicator",
     "tasks.max": "1",
+    "topic.config.sync": "false",
     "provenance.header.enable": "true"
   }
 }


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2432

_What behavior does this PR change, and why?_

Address the following warn message (by setting `topic.config.sync`; alternative was ACL management with `ALTER_CONFIGS`)

```
connect           | [2021-01-14 20:08:37,855] WARN Failed topic configuration check for destination topic wikipedia.parsed.ccloud.replica on task replicate-topic-to-ccloud-0 exception java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.TopicAuthorizationException: Topic authorization failed.. Will retry later. (io.confluent.connect.replicator.ReplicatorSourceTask)
```

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
