### PR TITLE
DEVX-2504: use v2 instead of v1 for Metrics API

### DIFF
--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -283,12 +283,12 @@ Metrics API
           {
             "timestamp": "2020-12-14T20:52:00Z",
             "value": 1744066,
-            "metric.label.topic": "wikipedia.parsed"
+            "metric.topic": "wikipedia.parsed"
           },
           {
             "timestamp": "2020-12-14T20:53:00Z",
             "value": 1847596,
-            "metric.label.topic": "wikipedia.parsed"
+            "metric.topic": "wikipedia.parsed"
           }
         ]
       }
@@ -341,7 +341,7 @@ Metrics API
           {
             "timestamp": "2020-12-14T20:00:00Z",
             "value": 1690522,
-            "metric.label.topic": "wikipedia.parsed.ccloud.replica"
+            "metric.topic": "wikipedia.parsed.ccloud.replica"
           }
         ]
       }

--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -261,7 +261,7 @@ Metrics API
       # View this parameter
       echo $DATA
 
-#. Send this query to the Metrics API endpoint at https://api.telemetry.confluent.cloud/v1/metrics/hosted-monitoring/query. For this query to work, you must have set the following parameters in your environment:
+#. Send this query to the Metrics API endpoint at https://api.telemetry.confluent.cloud/v2/metrics/hosted-monitoring/query. For this query to work, you must have set the following parameters in your environment:
 
    - ``METRICS_API_KEY``
    - ``METRICS_API_SECRET``
@@ -271,7 +271,7 @@ Metrics API
       curl -s -u ${METRICS_API_KEY}:${METRICS_API_SECRET} \
            --header 'content-type: application/json' \
            --data "${DATA}" \
-           https://api.telemetry.confluent.cloud/v1/metrics/hosted-monitoring/query \
+           https://api.telemetry.confluent.cloud/v2/metrics/hosted-monitoring/query \
               | jq .
 
 #. Your output should resemble the output below, showing metrics for the on-prem topic ``wikipedia.parsed``:
@@ -319,7 +319,7 @@ Metrics API
       # View this parameter
       echo $DATA
 
-#. Send this query to the Metrics API endpoint at https://api.telemetry.confluent.cloud/v1/metrics/cloud/query. For this query to work, you must have set the following parameters in your environment:
+#. Send this query to the Metrics API endpoint at https://api.telemetry.confluent.cloud/v2/metrics/cloud/query. For this query to work, you must have set the following parameters in your environment:
 
    - ``METRICS_API_KEY``
    - ``METRICS_API_SECRET`` 
@@ -329,7 +329,7 @@ Metrics API
       curl -s -u ${METRICS_API_KEY}:${METRICS_API_SECRET} \
            --header 'content-type: application/json' \
            --data "${DATA}" \
-           https://api.telemetry.confluent.cloud/v1/metrics/cloud/query \
+           https://api.telemetry.confluent.cloud/v2/metrics/cloud/query \
               | jq .
 
 #. Your output should resemble the output below, showing metrics for the |ccloud| topic ``wikipedia.parsed.ccloud.replica``:

--- a/docs/includes/metrics-api-intro.rst
+++ b/docs/includes/metrics-api-intro.rst
@@ -2,7 +2,7 @@ You can use the Metrics API to get data for both the on-prem cluster as well as 
 The Metrics API provides a queryable HTTP API in which you can post a query to get a time series of metrics.
 It can be used for observing both:
 
-- On-prem metrics (enabled by Telemetry Reporter) using the endpoint https://api.telemetry.confluent.cloud/v1/metrics/hosted-monitoring/query (this is in preview and the API may change)
-- |ccloud| metrics using the endpoint https://api.telemetry.confluent.cloud/v1/metrics/cloud/query
+- On-prem metrics (enabled by Telemetry Reporter) using the endpoint https://api.telemetry.confluent.cloud/v2/metrics/hosted-monitoring/query (this is in preview and the API may change)
+- |ccloud| metrics using the endpoint https://api.telemetry.confluent.cloud/v2/metrics/cloud/query
 
 .. figure:: images/metrics-api.jpg

--- a/scripts/ccloud/create-ccloud-workflow.sh
+++ b/scripts/ccloud/create-ccloud-workflow.sh
@@ -95,7 +95,7 @@ echo "DATA: $DATA"
 curl -s -u ${METRICS_API_KEY}:${METRICS_API_SECRET} \
      --header 'content-type: application/json' \
      --data "${DATA}" \
-     https://api.telemetry.confluent.cloud/v1/metrics/hosted-monitoring/query \
+     https://api.telemetry.confluent.cloud/v2/metrics/hosted-monitoring/query \
         | jq .
 
 # Confluent Cloud
@@ -107,7 +107,7 @@ echo "DATA: $DATA"
 curl -s -u ${METRICS_API_KEY}:${METRICS_API_SECRET} \
      --header 'content-type: application/json' \
      --data "${DATA}" \
-     https://api.telemetry.confluent.cloud/v1/metrics/cloud/query \
+     https://api.telemetry.confluent.cloud/v2/metrics/cloud/query \
         | jq .
 
 # Write ksqlDB queries

--- a/scripts/ccloud/metrics_query_ccloud.json
+++ b/scripts/ccloud/metrics_query_ccloud.json
@@ -13,7 +13,7 @@
                "value": "wikipedia.parsed.ccloud.replica"
           },
           {
-              "field": "metric.cluster_id",
+              "field": "resource.kafka.id",
               "op": "EQ",
               "value": "${CCLOUD_CLUSTER_ID}"
           }

--- a/scripts/ccloud/metrics_query_ccloud.json
+++ b/scripts/ccloud/metrics_query_ccloud.json
@@ -8,12 +8,12 @@
   "filter": {
       "filters": [
           {
-               "field": "metric.label.topic",
+               "field": "metric.topic",
                "op": "EQ",
                "value": "wikipedia.parsed.ccloud.replica"
           },
           {
-              "field": "metric.label.cluster_id",
+              "field": "metric.cluster_id",
               "op": "EQ",
               "value": "${CCLOUD_CLUSTER_ID}"
           }
@@ -23,7 +23,7 @@
   "intervals": ["${CURRENT_TIME_MINUS_1HR}/${CURRENT_TIME_PLUS_1HR}"],
   "granularity": "PT1H",
   "group_by": [
-      "metric.label.topic"
+      "metric.topic"
   ],
   "limit": 5
 }

--- a/scripts/ccloud/metrics_query_onprem.json
+++ b/scripts/ccloud/metrics_query_onprem.json
@@ -8,7 +8,7 @@
   "filter": {
       "filters": [
           {
-               "field": "metric.label.topic",
+               "field": "metric.topic",
                "op": "EQ",
                "value": "wikipedia.parsed"
           }
@@ -18,7 +18,7 @@
   "intervals": ["${CURRENT_TIME_MINUS_1HR}/${CURRENT_TIME_PLUS_1HR}"],
   "granularity": "PT1M",
   "group_by": [
-      "metric.label.topic"
+      "metric.topic"
   ],
   "limit": 5
 }


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2504

_What behavior does this PR change, and why?_

v2 is latest

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [x] Documentation
- [x] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation
- [ ] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->
