### PR TITLE
KSE-286: Fix multi-group-by persistence format

### DIFF
--- a/scripts/ksqlDB/statements.sql
+++ b/scripts/ksqlDB/statements.sql
@@ -1,4 +1,4 @@
-CREATE STREAM wikipedia WITH (kafka_topic='wikipedia.parsed', format='AVRO');
+CREATE STREAM wikipedia WITH (kafka_topic='wikipedia.parsed', value_format='AVRO');
 CREATE STREAM wikipedianobot AS SELECT *, (length->new - length->old) AS BYTECHANGE FROM wikipedia WHERE bot = false AND length IS NOT NULL AND length->new IS NOT NULL AND length->old IS NOT NULL;
 CREATE STREAM wikipediabot AS SELECT *, (length->new - length->old) AS BYTECHANGE FROM wikipedia WHERE bot = true AND length IS NOT NULL AND length->new IS NOT NULL AND length->old IS NOT NULL;
-CREATE TABLE wikipedia_count_gt_1 AS SELECT user, meta->uri AS URI, count(*) AS COUNT FROM wikipedia WINDOW TUMBLING (size 300 second) WHERE meta->domain = 'commons.wikimedia.org' GROUP BY user, meta->uri HAVING count(*) > 1;
+CREATE TABLE wikipedia_count_gt_1 WITH (key_format='JSON') AS SELECT user, meta->uri AS URI, count(*) AS COUNT FROM wikipedia WINDOW TUMBLING (size 300 second) WHERE meta->domain = 'commons.wikimedia.org' GROUP BY user, meta->uri HAVING count(*) > 1;

--- a/scripts/ksqlDB/statements.sql
+++ b/scripts/ksqlDB/statements.sql
@@ -1,4 +1,4 @@
-CREATE STREAM wikipedia WITH (kafka_topic='wikipedia.parsed', value_format='AVRO');
+CREATE STREAM wikipedia WITH (kafka_topic='wikipedia.parsed', format='AVRO');
 CREATE STREAM wikipedianobot AS SELECT *, (length->new - length->old) AS BYTECHANGE FROM wikipedia WHERE bot = false AND length IS NOT NULL AND length->new IS NOT NULL AND length->old IS NOT NULL;
 CREATE STREAM wikipediabot AS SELECT *, (length->new - length->old) AS BYTECHANGE FROM wikipedia WHERE bot = true AND length IS NOT NULL AND length->new IS NOT NULL AND length->old IS NOT NULL;
 CREATE TABLE wikipedia_count_gt_1 AS SELECT user, meta->uri AS URI, count(*) AS COUNT FROM wikipedia WINDOW TUMBLING (size 300 second) WHERE meta->domain = 'commons.wikimedia.org' GROUP BY user, meta->uri HAVING count(*) > 1;


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/KSE-286

In 6.2.0+, when multiple grouping criteria are used, ksqlDB requires the key format to be one of JSON, AVRO, PROTOBUF, DELIMITED, or JSON_SR. The default KAFKA format does not support multiple grouping criteria as of this version (and ksqlDB standalone 0.15+).

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
