### PR TITLE
DEVX-2630: Part 11. in the cp-demo tutorial is no longer an invalid k…

### DIFF
--- a/docs/on-prem.rst
+++ b/docs/on-prem.rst
@@ -338,7 +338,7 @@ Its embedded producer is configured to be idempotent, exactly-once in order sema
 
    .. sourcecode:: bash
 
-      SELECT ucase(cast(null as varchar)) FROM wikipedia EMIT CHANGES;
+      SELECT 1/0 FROM wikipedia EMIT CHANGES;
 
    No records should be returned from this query. ksqlDB writes errors into the processing log for each record. View the processing log topic ``ksql-clusterksql_processing_log`` with topic inspection (jump to offset 0/partition 0) or the corresponding ksqlDB stream ``KSQL_PROCESSING_LOG`` with the ksqlDB editor (set ``auto.offset.reset=earliest``).
 

--- a/scripts/validate/validate_ksqldb_processing_log.sh
+++ b/scripts/validate/validate_ksqldb_processing_log.sh
@@ -3,7 +3,7 @@
 # Run "bad" query
 echo "Running 'bad' query (approximately 60 seconds)"
 docker-compose exec ksqldb-cli bash -c "ksql -u ksqlDBUser -p ksqlDBUser http://ksqldb-server:8088 << EOF
-SELECT ucase(cast(null as varchar)) FROM wikipedia EMIT CHANGES LIMIT 20;
+SELECT 1/0 FROM wikipedia EMIT CHANGES LIMIT 20;
 exit ;
 EOF"
 


### PR DESCRIPTION
…sql query

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2630

the query: `SELECT ucase(cast(null as varchar)) FROM wikipedia EMIT CHANGES;`
posted in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html in step 11. under ksql in the cp-demo on prem tutorial no longer causes errors to be raised in the ksql_proccesing_log.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [x] Documentation
- [x] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
