### PR TITLE
DEVX-2622 & DEVX-2640: Update kstreams deps to CP versions and redact logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -943,7 +943,7 @@ services:
 
 
   streams-demo:
-    image: cnfldemos/cp-demo-kstreams:0.0.9
+    image: cnfldemos/cp-demo-kstreams:0.0.10
     restart: always
     depends_on:
       - kafka1
@@ -958,3 +958,4 @@ services:
       - ./env_files/streams-demo.env
     environment:
       KAFKA_REPLICATION_FACTOR: 2
+  

--- a/kstreams-app/build.gradle
+++ b/kstreams-app/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = 'io.confluent'
-version = '0.0.9'
+version = '0.0.10'
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
@@ -22,7 +22,6 @@ def props = new Properties()
 file("../env_files/config.env").withInputStream { props.load(it) }
 
 ext {
-  kafkaVersion = '2.6.0'
   cpVersion = props.getProperty("CONFLUENT") ?: '6.0.0'
 }
 
@@ -38,15 +37,17 @@ apply plugin: "com.commercehub.gradle.plugin.avro"
 apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-    compile "org.apache.avro:avro:1.9.1"
-    implementation "org.slf4j:slf4j-simple:1.7.26"
-    implementation "org.apache.kafka:kafka-streams:${kafkaVersion}"
-    implementation "io.confluent:kafka-streams-avro-serde:${cpVersion}"
+    implementation "org.apache.avro:avro:1.10.2"
+    implementation "org.slf4j:slf4j-simple:1.7.30"
+    implementation "org.apache.kafka:kafka-clients:${cpVersion}-ce"
+    implementation "org.apache.kafka:kafka-streams:${cpVersion}-ce"
     implementation "io.confluent:monitoring-interceptors:${cpVersion}"
-
-    testCompile "io.confluent:kafka-avro-serializer:${cpVersion}"
-    testCompile "org.apache.kafka:kafka-streams-test-utils:${kafkaVersion}"
-    testCompile "junit:junit:4.12"
+    implementation "io.confluent:kafka-avro-serializer:${cpVersion}"
+    implementation "io.confluent:kafka-streams-avro-serde:${cpVersion}"
+    implementation "org.apache.avro:avro-maven-plugin:1.8.2"
+    
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:${cpVersion}-ce"
+    testImplementation "junit:junit:4.13.2"
     testCompile "org.assertj:assertj-core:3.3.0"
 }
 

--- a/kstreams-app/build.gradle
+++ b/kstreams-app/build.gradle
@@ -22,7 +22,7 @@ def props = new Properties()
 file("../env_files/config.env").withInputStream { props.load(it) }
 
 ext {
-  cpVersion = props.getProperty("CONFLUENT") ?: '6.0.0'
+  cpVersion = props.getProperty("CONFLUENT") ?: '6.2.0'
 }
 
 repositories {

--- a/kstreams-app/src/main/java/io/confluent/demos/common/wiki/WikipediaActivityMonitor.java
+++ b/kstreams-app/src/main/java/io/confluent/demos/common/wiki/WikipediaActivityMonitor.java
@@ -136,7 +136,7 @@ class WikipediaActivityMonitor {
             loadEnvProperties(args[0]));
 
     final SpecificAvroSerde<WikiFeedMetric> metricSerde = new SpecificAvroSerde<>();
-    metricSerde.configure(propertiesToMap(props),false);
+    metricSerde.configure(propertiesToMap(props), false);
 
     final StreamsBuilder builder = new StreamsBuilder();
 

--- a/kstreams-app/src/main/java/io/confluent/demos/common/wiki/WikipediaActivityMonitor.java
+++ b/kstreams-app/src/main/java/io/confluent/demos/common/wiki/WikipediaActivityMonitor.java
@@ -100,7 +100,7 @@ class WikipediaActivityMonitor {
     final Enumeration<?> names = props.propertyNames();
     while (names.hasMoreElements()) {
       final String key = (String)names.nextElement();
-      rv.put(key, props.getProperty(key));
+      rv.put(key, props.get(key));
     }
     return rv;
   }

--- a/kstreams-app/src/main/jib/app/start.sh
+++ b/kstreams-app/src/main/jib/app/start.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
 /usr/local/bin/dub template /etc/confluent/docker/kafka.properties.template /etc/kafka/kafka-streams.properties
-echo $JAVA_OPTS
-echo $KAFKA_OPTS
-set
 java $JAVA_OPTS $KAFKA_OPTS -cp /app/resources:/app/classes:/app/libs/* io.confluent.demos.common.wiki.WikipediaActivityMonitor "/etc/kafka/kafka-streams.properties"
 


### PR DESCRIPTION
### Description 

* Updates kstreams-app startup script to remove logging of unecessary information
* Publishes new kstreams-app (0.10) and updates version used in cp-demo (https://hub.docker.com/layers/cnfldemos/cp-demo-kstreams)
* Moves streams library dependencies to current cpVersion + "ce". Reason for "ce" requirement isn't totally known, but the monitoring-interceptors library appears to transitively bring in the "ce" version of kafka-clients, and if the "ccs" or AK versions of the streams library is used, runtime errors are encountered.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [X] Run cp-demo


### Reviewer Tasks
- [ ] Run cp-demo