### PR TITLE
DEVX-2671: complete PR #379

### DIFF
--- a/scripts/sbc/docker-compose.yml
+++ b/scripts/sbc/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
       KAFKA_SASL_ENABLED_MECHANISMS: PLAIN, OAUTHBEARER
 
+      KAFKA_LISTENER_NAME_INTERNAL_SASL_ENABLED_MECHANISMS: PLAIN
       KAFKA_LISTENER_NAME_INTERNAL_PLAIN_SASL_JAAS_CONFIG: |
               org.apache.kafka.common.security.plain.PlainLoginModule required \
               username="admin" \
@@ -76,6 +77,7 @@ services:
       # Configure TOKEN listener for Confluent Platform components and impersonation
       KAFKA_LISTENER_NAME_TOKEN_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS: io.confluent.kafka.server.plugins.auth.token.TokenBearerValidatorCallbackHandler
       KAFKA_LISTENER_NAME_TOKEN_OAUTHBEARER_SASL_LOGIN_CALLBACK_HANDLER_CLASS: io.confluent.kafka.server.plugins.auth.token.TokenBearerServerLoginCallbackHandler
+      KAFKA_LISTENER_NAME_TOKEN_SASL_ENABLED_MECHANISMS: OAUTHBEARER
       KAFKA_LISTENER_NAME_TOKEN_OAUTHBEARER_SASL_JAAS_CONFIG: |
               org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
               publicKeyPath="/tmp/conf/public.pem";


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2671

_What behavior does this PR change, and why?_

This PR ties up one loose end from https://github.com/confluentinc/cp-demo/pull/379 , which is to make mods to the `docker-compose.yml` file used by SBC.

First I validated that the SBC script breaks in 6.2.0-post, then validated that the PR fixes the issue

```
[17:17:06] ~/git/cp-demo(DEVX-2671) ✗: ./scripts/sbc/add-broker.sh 
Signature ok
subject=C = US, ST = Ca, L = PaloAlto, O = CONFLUENT, OU = TEST, CN = kafka3
Getting CA Private Key
Certificate was added to keystore
Certificate reply was installed in keystore
Certificate was added to keystore
Certificate stored in file <kafka3.der>
Importing keystore kafka.kafka3.keystore.jks to kafka3.keystore.p12...
Entry for alias kafka3 successfully imported.
Entry for alias snakeoil-caroot successfully imported.
Import command completed:  2 entries successfully imported, 0 entries failed or cancelled
openldap is up-to-date
zookeeper is up-to-date
Creating kafka3 ... done
Waiting up to 120 seconds for SBC add broker to start rebalance planning
...kafka1            | [2021-09-15 21:17:36,809] INFO Addition status for broker 3 changed to PLAN_COMPUTATION (io.confluent.databalancer.ConfluentDataBalanceEngine)
✔ 

```

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
