### PR TITLE
Devx 2672: Enable cp-demo to be run in gitpod.io

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,35 @@
+github:
+  prebuilds:
+    # enable for the default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # configure whether Gitpod registers itself as a status check to pull requests
+    addCheck: false
+
+tasks:
+  - init: |
+      ./scripts/start.sh && ./scripts/stop.sh
+    command: |
+      curl -L --http1.1 https://cnfl.io/ccloud-cli | sudo sh -s -- -b /usr/local/bin
+      echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/overview.html"
+
+vscode:
+  extensions:
+    - ms-azuretools.vscode-docker
+
+ports:
+  - port: 1000-5600
+    onOpen: ignore
+  - port: 5601
+    onOpen: notify
+  - port: 5602-9020
+    onOpen: ignore
+  - port: 9021-9022
+    onOpen: notify
+  - port: 9023-13000
+    onOpen: ignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     hostname: openldap
     container_name: openldap
     ports:
-        - 389:389
+        - 1389:389
     environment:
         LDAP_ORGANISATION: "ConfluentDemo"
         LDAP_DOMAIN: "confluentdemo.io"

--- a/docs/on-prem.rst
+++ b/docs/on-prem.rst
@@ -19,6 +19,7 @@ If you prefer non-Docker examples, please go to `confluentinc/examples GitHub re
 
 After you run through the guided tutorial below, apply the concepts you learn here to build your own event streaming pipeline in |ccloud|, a fully managed, cloud-native event streaming platform powered by |ak|. When you sign up for `Confluent Cloud <https://confluent.cloud>`__, use the promo code ``CPDEMO50`` to receive an additional $50 free usage (`details <https://www.confluent.io/confluent-cloud-promo-disclaimer>`__).
 
+.. note:: Instead of running ``cp-demo`` locally with Docker, you can also run it in a cloud IDE using `gitpod.io <https://gitpod.io>`__ by following this `link <https://gitpod.io/#https://github.com/confluentinc/cp-demo>`__
 
 Prerequisites
 -------------

--- a/scripts/ccloud/create-ccloud-workflow.sh
+++ b/scripts/ccloud/create-ccloud-workflow.sh
@@ -33,8 +33,8 @@ ccloud::generate_configs $CONFIG_FILE
 source "delta_configs/env.delta"
 
 echo
-echo "Sleep an additional 60s to wait for all Confluent Cloud metadata to propagate"
-sleep 60
+echo "Sleep an additional 90s to wait for all Confluent Cloud metadata to propagate"
+sleep 90
 
 echo -e "\nStart Confluent Replicator to Confluent Cloud:"
 CONNECTOR_SUBMITTER="User:connectorSubmitter"

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -128,8 +128,17 @@ create_certificates()
 
   # Enable Docker appuser to read files when created by a different UID
   echo -e "Setting insecure permissions on some files in ${DIR}/../security for demo purposes\n"
+  if [[ "$OSTYPE" == "darwin"* ]]
+  then
+      # Mac OS
   chmod 644 ${DIR}/../security/keypair/keypair.pem
   chmod 644 ${DIR}/../security/*.key
+  else
+      # Linux
+      sudo chmod 644 ${DIR}/../security/keypair/keypair.pem
+      sudo chmod 644 ${DIR}/../security/*.key
+  fi
+
 }
 
 build_connect_image()


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2672

_What behavior does this PR change, and why?_

Allow to run cp-demo using [Gitpod.io](https://gitpod.io)

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

- [x] Run all steps from https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#module-1-on-prem-tutorial
- [x] Run all steps from https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/hybrid-cloud.html
- [ ] jmx-monitoring-stacks


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
