### PR TITLE
fix: Dockerfile-confluenthub connector uses REPOSITORY override if defined

### DIFF
--- a/Dockerfile-confluenthub
+++ b/Dockerfile-confluenthub
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 ARG CP_VERSION
-
-FROM confluentinc/cp-server-connect-base:$CP_VERSION
+ARG REPOSITORY
+FROM ${REPOSITORY}/cp-server-connect-base:$CP_VERSION
 
 ARG CONNECTOR_VERSION
 

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -116,8 +116,14 @@ build_connect_image()
   else
     DOCKERFILE="${DIR}/../../Dockerfile-confluenthub"
   fi
-  echo "docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f $DOCKERFILE ${DIR}/../../."
-  docker build --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f $DOCKERFILE ${DIR}/../../. || {
+  # If Repo defined, then use that, otherwise default to Dockerhub
+  if [ -z "${REPOSITORY}" ]; then
+          CONNECT_DOCKER_ARGS="--build-arg REPOSITORY=confluentinc/"
+  else
+          CONNECT_DOCKER_ARGS="--build-arg REPOSITORY=${REPOSITORY}"
+  fi
+  echo "docker build ${CONNECT_DOCKER_ARGS} --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f $DOCKERFILE ${DIR}/../../."
+  docker build ${CONNECT_DOCKER_ARGS} --build-arg CP_VERSION=${CONFLUENT_DOCKER_TAG} --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} -t localbuild/connect:${CONFLUENT_DOCKER_TAG}-${CONNECTOR_VERSION} -f $DOCKERFILE ${DIR}/../../. || {
     echo "ERROR: Docker image build failed. Please troubleshoot and try again. For troubleshooting instructions see https://docs.confluent.io/current/tutorials/cp-demo/docs/index.html#troubleshooting"
     exit 1
   }


### PR DESCRIPTION
This seems to be a long standing bug that I'm fixing here.

Locally tested against ECR images with minor `env_files/config.env` changes.