### PR TITLE
Get rid of password less sudo introduced in Devx 2672

### DIFF
--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -120,25 +120,16 @@ create_certificates()
   # Generate keys and certificates used for SSL
   echo -e "Generate keys and certificates used for SSL (see ${DIR}/security)"
   # Install findutils to be able to use 'xargs' in the certs-create.sh script
-  docker run -v ${DIR}/../security/:/etc/kafka/secrets/ -u0 confluentinc/cp-server:${CONFLUENT_DOCKER_TAG} bash -c "yum -y install findutils; cd /etc/kafka/secrets && ./certs-create.sh"
+  docker run -v ${DIR}/../security/:/etc/kafka/secrets/ -u0 $REPOSITORY/cp-server:${CONFLUENT_DOCKER_TAG} bash -c "yum -y install findutils; cd /etc/kafka/secrets && ./certs-create.sh && chown -R $(id -u $USER):$(id -g $USER) /etc/kafka/secrets"
 
   # Generating public and private keys for token signing
   echo "Generating public and private keys for token signing"
-  docker run -v ${DIR}/../security/:/etc/kafka/secrets/ -u0 confluentinc/cp-server:${CONFLUENT_DOCKER_TAG} bash -c "mkdir -p /etc/kafka/secrets/keypair; openssl genrsa -out /etc/kafka/secrets/keypair/keypair.pem 2048; openssl rsa -in /etc/kafka/secrets/keypair/keypair.pem -outform PEM -pubout -out /etc/kafka/secrets/keypair/public.pem"
+  docker run -v ${DIR}/../security/:/etc/kafka/secrets/ -u0 $REPOSITORY/cp-server:${CONFLUENT_DOCKER_TAG} bash -c "mkdir -p /etc/kafka/secrets/keypair; openssl genrsa -out /etc/kafka/secrets/keypair/keypair.pem 2048; openssl rsa -in /etc/kafka/secrets/keypair/keypair.pem -outform PEM -pubout -out /etc/kafka/secrets/keypair/public.pem && chown -R $(id -u $USER):$(id -g $USER) /etc/kafka/secrets/keypair"
 
   # Enable Docker appuser to read files when created by a different UID
   echo -e "Setting insecure permissions on some files in ${DIR}/../security for demo purposes\n"
-  if [[ "$OSTYPE" == "darwin"* ]]
-  then
-      # Mac OS
-      chmod 644 ${DIR}/../security/keypair/keypair.pem
-      chmod 644 ${DIR}/../security/*.key
-  else
-      # Linux
-      sudo chmod 644 ${DIR}/../security/keypair/keypair.pem
-      sudo chmod 644 ${DIR}/../security/*.key
-  fi
-
+  chmod 644 ${DIR}/../security/keypair/keypair.pem
+  chmod 644 ${DIR}/../security/*.key
 }
 
 build_connect_image()


### PR DESCRIPTION
### Description 

With this [commit](https://github.com/confluentinc/cp-demo/pull/390/commits/8056a4fcb5af743c103c0173a15d1cb66afbf7b0) was introduced the need to have "sudo password less" on Linux, which is not the case for every setup. For a linux user using cp-demo, the start script was requiring to enter password for sudo:

```
[sudo] password for myuser:
```

_What behavior does this PR change, and why?_

* SAME: run the ephemeral container, using root so that it can install stuff (findutils in cp-demo)
* NEW: run a chown in the ephemeral container using a passed in uid:gid so that the files created are now owned by the user that started the ephemeral container
* NEW: no more sudo required for handling those files in the host environment)


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

Run cp-demo with `CLEAN=true` and verified permissions are same as running user after the call to `create_certificates()`:

Example:

```
gitpod /workspace/cp-demo/scripts/security $ ls -lrt
total 1024
-rw-r--r-- 1 gitpod gitpod    144 Oct 12 18:02 zookeeper_jaas.conf
drwxr-xr-x 2 gitpod gitpod   4096 Oct 12 18:02 ldap_users
-rw-r--r-- 1 gitpod gitpod    261 Oct 12 18:02 ksqlDBUser_without_interceptors_ssl.config
-rw-r--r-- 1 gitpod gitpod    263 Oct 12 18:02 connectorSA_without_interceptors_ssl.config
-rw-r--r-- 1 gitpod gitpod    265 Oct 12 18:02 client_without_interceptors_ssl.config
-rw-r--r-- 1 gitpod gitpod    794 Oct 12 18:02 client_with_interceptors.config
-rw-r--r-- 1 gitpod gitpod    194 Oct 12 18:02 client_sasl_plain.config
-rw-r--r-- 1 gitpod gitpod    822 Oct 12 18:02 clientListen_with_interceptors.config
-rwxr-xr-x 1 gitpod gitpod    650 Oct 12 18:02 certs-verify.sh
-rwxr-xr-x 1 gitpod gitpod   1507 Oct 12 18:02 certs-create.sh
-rwxr-xr-x 1 gitpod gitpod   3594 Oct 12 18:02 certs-create-per-user.sh
-rwxr-xr-x 1 gitpod gitpod    272 Oct 12 18:02 certs-clean.sh
-rw-r--r-- 1 gitpod gitpod    134 Oct 12 18:02 broker_jaas.conf
-rw-r--r-- 1 gitpod gitpod    251 Oct 12 18:02 appSA.config
drwxr-xr-x 2 gitpod gitpod     43 Oct 12 18:04 keypair
-rw-r--r-- 1 gitpod gitpod   1854 Oct 13 08:04 snakeoil-ca-1.key
-rw-r--r-- 1 gitpod gitpod   1375 Oct 13 08:04 snakeoil-ca-1.crt
-rw-r--r-- 1 gitpod gitpod   1125 Oct 13 08:05 connect.csr
-rw-r--r-- 1 gitpod gitpod   1121 Oct 13 08:05 appSA.csr
-rw-r--r-- 1 gitpod gitpod   1310 Oct 13 08:05 connect-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1125 Oct 13 08:05 kafka1.csr
-rw-r--r-- 1 gitpod gitpod   1302 Oct 13 08:05 appSA-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1125 Oct 13 08:05 kafka2.csr
-rw-r--r-- 1 gitpod gitpod   1139 Oct 13 08:05 connectorSA.csr
-rw-r--r-- 1 gitpod gitpod   1306 Oct 13 08:05 kafka2-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1133 Oct 13 08:05 restproxy.csr
-rw-r--r-- 1 gitpod gitpod   1147 Oct 13 08:05 schemaregistry.csr
-rw-r--r-- 1 gitpod gitpod   1306 Oct 13 08:05 kafka1-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1143 Oct 13 08:05 clientListen.csr
-rw-r--r-- 1 gitpod gitpod   1318 Oct 13 08:05 connectorSA-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1133 Oct 13 08:05 zookeeper.csr
-rw-r--r-- 1 gitpod gitpod   1125 Oct 13 08:05 badapp.csr
-rw-r--r-- 1 gitpod gitpod   1125 Oct 13 08:05 client.csr
-rw-r--r-- 1 gitpod gitpod   1314 Oct 13 08:05 restproxy-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1326 Oct 13 08:05 schemaregistry-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1314 Oct 13 08:05 zookeeper-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1133 Oct 13 08:05 ksqlDBUser.csr
-rw-r--r-- 1 gitpod gitpod   1306 Oct 13 08:05 client-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1117 Oct 13 08:05 mds.csr
-rw-r--r-- 1 gitpod gitpod   1306 Oct 13 08:05 badapp-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1322 Oct 13 08:05 clientListen-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1318 Oct 13 08:05 ksqlDBUser-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1183 Oct 13 08:05 controlCenterAndKsqlDBServer.csr
-rw-r--r-- 1 gitpod gitpod   1318 Oct 13 08:05 mds-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   1407 Oct 13 08:05 controlCenterAndKsqlDBServer-ca1-signed.crt
-rw-r--r-- 1 gitpod gitpod   5019 Oct 13 08:05 kafka.connect.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5017 Oct 13 08:05 kafka.kafka1.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5015 Oct 13 08:05 kafka.appSA.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5017 Oct 13 08:05 kafka.kafka2.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5065 Oct 13 08:05 kafka.schemaregistry.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5059 Oct 13 08:05 kafka.connectorSA.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5039 Oct 13 08:05 kafka.zookeeper.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5039 Oct 13 08:05 kafka.restproxy.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5017 Oct 13 08:05 kafka.client.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5017 Oct 13 08:05 kafka.badapp.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5061 Oct 13 08:05 kafka.clientListen.keystore.jks
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 connect_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 connect_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 connect_keystore_creds
-rw-r--r-- 1 gitpod gitpod   5189 Oct 13 08:05 kafka.controlCenterAndKsqlDBServer.keystore.jks
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.appSA.truststore.jks
-rw-r--r-- 1 gitpod gitpod   5041 Oct 13 08:05 kafka.ksqlDBUser.keystore.jks
-rw-r--r-- 1 gitpod gitpod   5027 Oct 13 08:05 kafka.mds.keystore.jks
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 appSA_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 appSA_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 appSA_keystore_creds
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.kafka1.truststore.jks
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.connectorSA.truststore.jks
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.schemaregistry.truststore.jks
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 kafka1_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 kafka1_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 kafka1_keystore_creds
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.kafka2.truststore.jks
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.zookeeper.truststore.jks
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 schemaregistry_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 schemaregistry_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 schemaregistry_keystore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 connectorSA_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 connectorSA_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 connectorSA_keystore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 kafka2_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 kafka2_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 kafka2_keystore_creds
-rw-r--r-- 1 gitpod gitpod    925 Oct 13 08:05 connect.der
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 zookeeper_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 zookeeper_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 zookeeper_keystore_creds
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.restproxy.truststore.jks
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.clientListen.truststore.jks
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.client.truststore.jks
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 restproxy_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 restproxy_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 restproxy_keystore_creds
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.controlCenterAndKsqlDBServer.truststore.jks
-rw-r--r-- 1 gitpod gitpod   1310 Oct 13 08:05 connect.certificate.pem
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.badapp.truststore.jks
-rw-r--r-- 1 gitpod gitpod    920 Oct 13 08:05 appSA.der
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 client_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 client_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 client_keystore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 controlCenterAndKsqlDBServer_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 controlCenterAndKsqlDBServer_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 controlCenterAndKsqlDBServer_keystore_creds
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.ksqlDBUser.truststore.jks
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 clientListen_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 clientListen_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 clientListen_keystore_creds
-rw-r--r-- 1 gitpod gitpod   1302 Oct 13 08:05 appSA.certificate.pem
-rw-r--r-- 1 gitpod gitpod    923 Oct 13 08:05 kafka1.der
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 ksqlDBUser_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 ksqlDBUser_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 ksqlDBUser_keystore_creds
-rw-r--r-- 1 gitpod gitpod   1351 Oct 13 08:05 kafka.mds.truststore.jks
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 mds_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 mds_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 mds_keystore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 badapp_truststore_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 badapp_sslkey_creds
-rw-r--r-- 1 gitpod gitpod     10 Oct 13 08:05 badapp_keystore_creds
-rw-r--r-- 1 gitpod gitpod   1306 Oct 13 08:05 kafka1.certificate.pem
-rw-r--r-- 1 gitpod gitpod    933 Oct 13 08:05 connectorSA.der
-rw-r--r-- 1 gitpod gitpod    922 Oct 13 08:05 kafka2.der
-rw-r--r-- 1 gitpod gitpod    928 Oct 13 08:05 zookeeper.der
-rw-r--r-- 1 gitpod gitpod   1318 Oct 13 08:05 connectorSA.certificate.pem
-rw-r--r-- 1 gitpod gitpod   1306 Oct 13 08:05 kafka2.certificate.pem
-rw-r--r-- 1 gitpod gitpod    938 Oct 13 08:05 schemaregistry.der
-rw-r--r-- 1 gitpod gitpod   1326 Oct 13 08:05 schemaregistry.certificate.pem
-rw-r--r-- 1 gitpod gitpod    998 Oct 13 08:05 controlCenterAndKsqlDBServer.der
-rw-r--r-- 1 gitpod gitpod    935 Oct 13 08:05 clientListen.der
-rw-r--r-- 1 gitpod gitpod    922 Oct 13 08:05 client.der
-rw-r--r-- 1 gitpod gitpod   1314 Oct 13 08:05 zookeeper.certificate.pem
-rw-r--r-- 1 gitpod gitpod    928 Oct 13 08:05 restproxy.der
-rw-r--r-- 1 gitpod gitpod   1322 Oct 13 08:05 clientListen.certificate.pem
-rw-r--r-- 1 gitpod gitpod   1306 Oct 13 08:05 client.certificate.pem
-rw-r--r-- 1 gitpod gitpod   1407 Oct 13 08:05 controlCenterAndKsqlDBServer.certificate.pem
-rw-r--r-- 1 gitpod gitpod    931 Oct 13 08:05 ksqlDBUser.der
-rw-r--r-- 1 gitpod gitpod    933 Oct 13 08:05 mds.der
-rw-r--r-- 1 gitpod gitpod   1314 Oct 13 08:05 restproxy.certificate.pem
-rw-r--r-- 1 gitpod gitpod    532 Oct 13 08:05 certs-create-connect.log
-rw-r--r-- 1 gitpod gitpod   1318 Oct 13 08:05 mds.certificate.pem
-rw-r--r-- 1 gitpod gitpod   1318 Oct 13 08:05 ksqlDBUser.certificate.pem
-rw-r--r-- 1 gitpod gitpod   5019 Oct 13 08:05 connect.keystore.p12
-rw-r--r-- 1 gitpod gitpod    522 Oct 13 08:05 certs-create-appSA.log
-rw-r--r-- 1 gitpod gitpod    922 Oct 13 08:05 badapp.der
-rw-r--r-- 1 gitpod gitpod   5015 Oct 13 08:05 appSA.keystore.p12
-rw-r--r-- 1 gitpod gitpod   1844 Oct 13 08:05 connect.key
-rw-r--r-- 1 gitpod gitpod   1306 Oct 13 08:05 badapp.certificate.pem
-rw-r--r-- 1 gitpod gitpod    527 Oct 13 08:05 certs-create-kafka1.log
-rw-r--r-- 1 gitpod gitpod   1846 Oct 13 08:05 appSA.key
-rw-r--r-- 1 gitpod gitpod   5017 Oct 13 08:05 kafka1.keystore.p12
-rw-r--r-- 1 gitpod gitpod    527 Oct 13 08:05 certs-create-kafka2.log
-rw-r--r-- 1 gitpod gitpod   1847 Oct 13 08:05 kafka1.key
-rw-r--r-- 1 gitpod gitpod    552 Oct 13 08:05 certs-create-connectorSA.log
-rw-r--r-- 1 gitpod gitpod   5017 Oct 13 08:05 kafka2.keystore.p12
-rw-r--r-- 1 gitpod gitpod    567 Oct 13 08:05 certs-create-schemaregistry.log
-rw-r--r-- 1 gitpod gitpod   5059 Oct 13 08:05 connectorSA.keystore.p12
-rw-r--r-- 1 gitpod gitpod   5065 Oct 13 08:05 schemaregistry.keystore.p12
-rw-r--r-- 1 gitpod gitpod    542 Oct 13 08:05 certs-create-zookeeper.log
-rw-r--r-- 1 gitpod gitpod   1847 Oct 13 08:05 kafka2.key
-rw-r--r-- 1 gitpod gitpod   5039 Oct 13 08:05 zookeeper.keystore.p12
-rw-r--r-- 1 gitpod gitpod   1852 Oct 13 08:05 connectorSA.key
-rw-r--r-- 1 gitpod gitpod   1855 Oct 13 08:05 schemaregistry.key
-rw-r--r-- 1 gitpod gitpod    637 Oct 13 08:05 certs-create-controlCenterAndKsqlDBServer.log
-rw-r--r-- 1 gitpod gitpod    527 Oct 13 08:05 certs-create-client.log
-rw-r--r-- 1 gitpod gitpod   5017 Oct 13 08:05 client.keystore.p12
-rw-r--r-- 1 gitpod gitpod   5189 Oct 13 08:05 controlCenterAndKsqlDBServer.keystore.p12
-rw-r--r-- 1 gitpod gitpod   1850 Oct 13 08:05 zookeeper.key
-rw-r--r-- 1 gitpod gitpod    542 Oct 13 08:05 certs-create-restproxy.log
-rw-r--r-- 1 gitpod gitpod    557 Oct 13 08:05 certs-create-clientListen.log
-rw-r--r-- 1 gitpod gitpod   1847 Oct 13 08:05 client.key
-rw-r--r-- 1 gitpod gitpod   1869 Oct 13 08:05 controlCenterAndKsqlDBServer.key
-rw-r--r-- 1 gitpod gitpod    512 Oct 13 08:05 certs-create-mds.log
-rw-r--r-- 1 gitpod gitpod   5039 Oct 13 08:05 restproxy.keystore.p12
-rw-r--r-- 1 gitpod gitpod   5061 Oct 13 08:05 clientListen.keystore.p12
-rw-r--r-- 1 gitpod gitpod   5027 Oct 13 08:05 mds.keystore.p12
-rw-r--r-- 1 gitpod gitpod    547 Oct 13 08:05 certs-create-ksqlDBUser.log
-rw-r--r-- 1 gitpod gitpod   1850 Oct 13 08:05 restproxy.key
-rw-r--r-- 1 gitpod gitpod    527 Oct 13 08:05 certs-create-badapp.log
-rw-r--r-- 1 gitpod gitpod   1844 Oct 13 08:05 mds.key
-rw-r--r-- 1 gitpod gitpod   5041 Oct 13 08:05 ksqlDBUser.keystore.p12
-rw-r--r-- 1 gitpod gitpod   1853 Oct 13 08:05 clientListen.key
-rw-r--r-- 1 gitpod gitpod   5017 Oct 13 08:05 badapp.keystore.p12
-rw-r--r-- 1 gitpod gitpod   1851 Oct 13 08:05 ksqlDBUser.key
-rw-r--r-- 1 gitpod gitpod   1847 Oct 13 08:05 badapp.key
-rw-r--r-- 1 gitpod gitpod 181697 Oct 13 08:07 kafka.connect.truststore.jks
```

Also verified that `certs_clean.sh` is working

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
