### PR TITLE
corrected CN for badapp in ldap group definition

### DIFF
--- a/scripts/security/ldap_users/20_group_add.ldif
+++ b/scripts/security/ldap_users/20_group_add.ldif
@@ -71,7 +71,7 @@ memberuid: cn=appSA,ou=users,{{ LDAP_BASE_DN }}
 dn: cn=KafkaDevelopers,ou=groups,{{ LDAP_BASE_DN }}
 changetype: modify
 add: memberuid
-memberuid: cn=badApp,ou=users,{{ LDAP_BASE_DN }}
+memberuid: cn=badapp,ou=users,{{ LDAP_BASE_DN }}
 
 dn: cn=KafkaDevelopers,ou=groups,{{ LDAP_BASE_DN }}
 changetype: modify


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_

RBAC rolebindings assigned to Group:KafkaDevelopers were not assigned to user badapp due to typo in LDAP group membership (badApp)


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

I ran cp-demo with the fix and verified rolebindings to group were available to badapp

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
