### PR TITLE
Include JMX Monitoring stacks on Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,7 @@ github:
 tasks:
   - name: prebuild
     init: |
-      cd .. && git clone https://github.com/confluentinc/jmx-monitoring-stacks && cd ../cp-demo/. \
+      cd .. && git clone https://github.com/confluentinc/jmx-monitoring-stacks && cd ../cp-demo/. && \
         ./scripts/start.sh && ./scripts/stop.sh && \
         gp sync-done prebuild
     command: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,6 +6,8 @@ github:
     branches: true
     # enable for pull requests coming from this repo (defaults to true)
     pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
     addComment: true
     # configure whether Gitpod registers itself as a status check to pull requests

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,11 +15,8 @@ github:
 
 tasks:
   - name: prebuild
-    init: |
-      ./scripts/start.sh && ./scripts/stop.sh && gp sync-done prebuild
-    command: |
-      curl -L --http1.1 https://cnfl.io/ccloud-cli | \
-        sudo sh -s -- -b /usr/local/bin; exit
+    init: ./scripts/start.sh && ./scripts/stop.sh && gp sync-done prebuild
+    command: curl -L --http1.1 https://cnfl.io/ccloud-cli | sudo sh -s -- -b /usr/local/bin; exit
 
   - name: cp-demo
     init: gp sync-await prebuild

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,7 @@ github:
 tasks:
   - name: prebuild
     init: |
-      cd .. && git clone https://github.com/confluentinc/jmx-monitoring-stacks && cd ../cp-demo/. && \
+      cd .. && git clone https://github.com/confluentinc/jmx-monitoring-stacks && cd cp-demo/. && \
         ./scripts/start.sh && ./scripts/stop.sh && \
         gp sync-done prebuild
     command: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -26,7 +26,7 @@ tasks:
     command: |
       if [ -z "$DISABLE_AUTOSTART" ]; then
         echo "🚀 Starting up cp-demo (you can disable autostart by exporting DISABLE_AUTOSTART environment variable, see https://www.gitpod.io/docs/environment-variables)";
-        if [ -z "$MONITORING_STACK"]; then
+        if [ -z "$MONITORING_STACK" ]; then
           echo "cp-demo is not including any JMX monitoring stack (you can enable them by exporting MONITORING_STACK environment variable, see https://github.com/confluentinc/jmx-monitoring-stacks)."
           ./scripts/start.sh;
         else

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,9 +16,7 @@ github:
 tasks:
   - name: prebuild
     init: |
-      cd .. && git clone https://github.com/confluentinc/jmx-monitoring-stacks && cd cp-demo/. && \
-        ./scripts/start.sh && ./scripts/stop.sh && \
-        gp sync-done prebuild
+      ./scripts/start.sh && ./scripts/stop.sh && gp sync-done prebuild
     command: |
       curl -L --http1.1 https://cnfl.io/ccloud-cli | \
         sudo sh -s -- -b /usr/local/bin; exit
@@ -30,11 +28,12 @@ tasks:
         echo "🚀 Starting up cp-demo (you can disable autostart by exporting DISABLE_AUTOSTART environment variable, see https://www.gitpod.io/docs/environment-variables)";
         if [ -z "$MONITORING_STACK" ]; then
           echo "cp-demo is not including any JMX monitoring stack (you can enable them by exporting MONITORING_STACK environment variable, see https://github.com/confluentinc/jmx-monitoring-stacks)."
-          ./scripts/start.sh;
+          CLEAN=true ./scripts/start.sh
         else
           echo "cp-demo includes JMX monitoring stack $MONITORING_STACK"
-          cd ../jmx-monitoring-stacks
-          ./$MONITORING_STACK/start.sh;
+          cd .. && git clone https://github.com/confluentinc/jmx-monitoring-stacks 
+          cd ./jmx-monitoring-stacks
+          CLEAN=true ./$MONITORING_STACK/start.sh;
         fi
         echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial";
       else

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,12 +13,31 @@ github:
 
 tasks:
   - name: prebuild
-    init: ./scripts/start.sh && ./scripts/stop.sh && gp sync-done prebuild
-    command: curl -L --http1.1 https://cnfl.io/ccloud-cli | sudo sh -s -- -b /usr/local/bin; exit
+    init: |
+      cd .. && git clone https://github.com/confluentinc/jmx-monitoring-stacks && cd ../cp-demo/. \
+        ./scripts/start.sh && ./scripts/stop.sh && \
+        gp sync-done prebuild
+    command: |
+      curl -L --http1.1 https://cnfl.io/ccloud-cli | \
+        sudo sh -s -- -b /usr/local/bin; exit
 
   - name: cp-demo
     init: gp sync-await prebuild
-    command: if [ -z "$DISABLE_AUTOSTART" ]; then echo "🚀 Starting up cp-demo (you can disable autostart by exporting DISABLE_AUTOSTART environment variable, see https://www.gitpod.io/docs/environment-variables)";./scripts/start.sh; echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"; else echo "ℹ️ DISABLE_AUTOSTART environment variable is set, use ./scripts/start.sh to start cp-demo";fi
+    command: |
+      if [ -z "$DISABLE_AUTOSTART" ]; then
+        echo "🚀 Starting up cp-demo (you can disable autostart by exporting DISABLE_AUTOSTART environment variable, see https://www.gitpod.io/docs/environment-variables)";
+        if [ -z "$MONITORING_STACK"]; then
+          echo "cp-demo is not including any JMX monitoring stack (you can enable them by exporting MONITORING_STACK environment variable, see https://github.com/confluentinc/jmx-monitoring-stacks)."
+          ./scripts/start.sh;
+        else
+          echo "cp-demo includes JMX monitoring stack $MONITORING_STACK"
+          cd ../jmx-monitoring-stacks
+          ./$MONITORING_STACK/start.sh;
+        fi
+        echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial";
+      else
+        echo "ℹ️ DISABLE_AUTOSTART environment variable is set, use ./scripts/start.sh to start cp-demo";
+      fi
 
 vscode:
   extensions:
@@ -81,3 +100,11 @@ ports:
 # restproxy
 - port: 8086
   onOpen: ignore
+# prometheus
+- port: 9090
+  onOpen: notify
+  visibility: public
+# grafana
+- port: 3000
+  onOpen: notify
+  visibility: public


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_

While enabling gitpod on jmx-monitoring-stacks repo (https://github.com/confluentinc/jmx-monitoring-stacks/pull/54), it made sense to extend cp-demo instead of copy/paste'ing most of the gitpod configuration in another project.

This PR adds a new variable `MONITORING_STACK` to choose which stack to start, if any, when starting cp-demo on gitpod.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
