### PR TITLE
DEVX-2686: make null-safe reference to GITPOD_WORKSPACE_URL

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -27,7 +27,7 @@ else
 fi
 
 # Gitpod only supports the C3_KSQLDB_HTTPS=false scenario and exposes services with a custom URL
-if [[ -n "$GITPOD_WORKSPACE_URL" ]]; then
+if [[ -n "${GITPOD_WORKSPACE_URL:-}" ]]; then
   C3_KSQLDB_HTTPS="false"
   export CONTROL_CENTER_KSQL_WIKIPEDIA_URL="http://ksqldb-server:8088"
   export CONTROL_CENTER_KSQL_WIKIPEDIA_ADVERTISED_URL="https://8088-${GITPOD_WORKSPACE_URL#https://}"


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2686

_What behavior does this PR change, and why?_

Fix this error when running `add-broker.sh` from SBC demo:

```
cp-demo/scripts/sbc/../env.sh: line 30: GITPOD_WORKSPACE_URL: unbound variable
```

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
 - [ ] Documentation
 - [X] Run cp-demo 


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
