### PR TITLE
fix regression devx-2689

### DIFF
--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -120,25 +120,16 @@ create_certificates()
   # Generate keys and certificates used for SSL
   echo -e "Generate keys and certificates used for SSL (see ${DIR}/security)"
   # Install findutils to be able to use 'xargs' in the certs-create.sh script
-  docker run -v ${DIR}/../security/:/etc/kafka/secrets/ -u0 confluentinc/cp-server:${CONFLUENT_DOCKER_TAG} bash -c "yum -y install findutils; cd /etc/kafka/secrets && ./certs-create.sh"
-
+  docker run -v ${DIR}/../security/:/etc/kafka/secrets/ -u0 $REPOSITORY/cp-server:${CONFLUENT_DOCKER_TAG} bash -c "yum -y install findutils; cd /etc/kafka/secrets && ./certs-create.sh && chown -R $(id -u $USER):$(id -g $USER) /etc/kafka/secrets"
+  
   # Generating public and private keys for token signing
   echo "Generating public and private keys for token signing"
-  docker run -v ${DIR}/../security/:/etc/kafka/secrets/ -u0 confluentinc/cp-server:${CONFLUENT_DOCKER_TAG} bash -c "mkdir -p /etc/kafka/secrets/keypair; openssl genrsa -out /etc/kafka/secrets/keypair/keypair.pem 2048; openssl rsa -in /etc/kafka/secrets/keypair/keypair.pem -outform PEM -pubout -out /etc/kafka/secrets/keypair/public.pem"
+  docker run -v ${DIR}/../security/:/etc/kafka/secrets/ -u0 $REPOSITORY/cp-server:${CONFLUENT_DOCKER_TAG} bash -c "mkdir -p /etc/kafka/secrets/keypair; openssl genrsa -out /etc/kafka/secrets/keypair/keypair.pem 2048; openssl rsa -in /etc/kafka/secrets/keypair/keypair.pem -outform PEM -pubout -out /etc/kafka/secrets/keypair/public.pem && chown -R $(id -u $USER):$(id -g $USER) /etc/kafka/secrets/keypair"
 
   # Enable Docker appuser to read files when created by a different UID
   echo -e "Setting insecure permissions on some files in ${DIR}/../security for demo purposes\n"
-  if [[ "$OSTYPE" == "darwin"* ]]
-  then
-      # Mac OS
-      chmod 644 ${DIR}/../security/keypair/keypair.pem
-      chmod 644 ${DIR}/../security/*.key
-  else
-      # Linux
-      sudo chmod 644 ${DIR}/../security/keypair/keypair.pem
-      sudo chmod 644 ${DIR}/../security/*.key
-  fi
-
+  chmod 644 ${DIR}/../security/keypair/keypair.pem
+  chmod 644 ${DIR}/../security/*.key
 }
 
 build_connect_image()


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2689

_What behavior does this PR change, and why?_
This PR fixes a regression (also described in DEVX-2689):

- DevX2676 introduces a `sudo` command (2x) to enable overwriting root-privileged files (in `functions.sh | create_certificates()`).
- This assumes passwordless sudo is enabled on the docker host system
- A fix was introduced approved and merged into 6.2.0-post in PR #396
- This fix was overwritten 4 days later in commit dd3b2f65fafc845a0abb0a8cc4defd884a1c6af7

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

* BEFORE code change: starting `cp-demo` with `CLEAN=true` was failing for me.
* AFTER re-applying the changes from the previous commit/PR
* I was able to run and re-run `cp-demo` with `CLEAN=true` locally (Win10/WSL2/Ubuntu20.04)
* I was able to run and re-run `cp-demo` with `CLEAN=true` in `gitpod`

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] Run cp-demo (on Win10/WSL2/Ubuntu20.04)
- [x] jmx-monitoring-stacks (on Win10/WSL2/Ubuntu20.04)
- [x] gitpod

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [ ] Run cp-demo
- [ ] jmx-monitoring-stacks
- [ ] gitpod