### PR TITLE
TMM-3: Add `--no-TTY` to `docker-compose exec` commands to fix validation scripts in newer versions on docker

### DIFF
--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -239,8 +239,8 @@ Metrics API
 
    .. code-block:: text
 
-      CURRENT_TIME_MINUS_1HR=$(docker-compose exec tools date -Is -d '-1 hour' | tr -d '\r')
-      CURRENT_TIME_PLUS_1HR=$(docker-compose exec tools date -Is -d '+1 hour' | tr -d '\r')
+      CURRENT_TIME_MINUS_1HR=$(docker-compose exec --no-TTY tools date -Is -d '-1 hour' | tr -d '\r')
+      CURRENT_TIME_PLUS_1HR=$(docker-compose exec --no-TTY tools date -Is -d '+1 hour' | tr -d '\r')
 
 #. For the on-prem metrics: view the :devx-cp-demo:`metrics query file|scripts/ccloud/metrics_query_onprem.json`, which requests ``io.confluent.kafka.server/received_bytes`` for the topic ``wikipedia.parsed`` in the on-prem cluster (for all queryable metrics examples, see `Metrics API <https://docs.confluent.io/cloud/current/monitoring/metrics-api.html>`__).
 

--- a/docs/on-prem.rst
+++ b/docs/on-prem.rst
@@ -755,7 +755,7 @@ The security in place between |sr| and the end clients, e.g. ``appSA``, is as fo
 
    .. code-block:: text
 
-       docker-compose exec schemaregistry curl -X GET \
+       docker-compose exec --no-TTY schemaregistry curl -s -X GET \
           --tlsv1.2 \
           --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
           -u superUser:superUser \
@@ -858,7 +858,7 @@ The security in place between |sr| and the end clients, e.g. ``appSA``, is as fo
 
    .. code-block:: text
 
-       docker-compose exec schemaregistry curl -X GET \
+       docker-compose exec --no-TTY schemaregistry curl -s -X GET \
           --tlsv1.2 \
           --cacert /etc/kafka/secrets/snakeoil-ca-1.crt \
           -u appSA:appSA \

--- a/docs/on-prem.rst
+++ b/docs/on-prem.rst
@@ -27,10 +27,10 @@ Prerequisites
 
 This example has been validated with:
 
--  Docker version 17.06.1-ce
--  Docker Compose version 1.16.0 with Docker Compose file format 2.3
+-  Docker engine version 20.10.12
+-  Docker Compose version 2.2.3 with Docker Compose file format 2.3
 -  Java version 1.8.0_92
--  MacOS 10.15.3 (note for `Ubuntu environments <https://github.com/confluentinc/cp-demo/issues/53>`__)
+-  MacOS 12.2.1 (note for `Ubuntu environments <https://github.com/confluentinc/cp-demo/issues/53>`__)
 -  OpenSSL 1.1.1d
 -  git
 -  curl

--- a/docs/on-prem.rst
+++ b/docs/on-prem.rst
@@ -1203,7 +1203,7 @@ For the next few steps, use the |crest| that is embedded on the |ak| brokers. On
 
    .. code-block:: text
 
-      docker-compose exec restproxy curl -X POST \
+      docker-compose exec --no-TTY restproxy curl -s -X POST \
          -H "Content-Type: application/json" \
          -H "accept: application/json" \
          -d "{\"topic_name\":\"dev_users\",\"partitions_count\":64,\"replication_factor\":2,\"configs\":[{\"name\":\"cleanup.policy\",\"value\":\"compact\"},{\"name\":\"compression.type\",\"value\":\"gzip\"}]}" \
@@ -1224,7 +1224,7 @@ For the next few steps, use the |crest| that is embedded on the |ak| brokers. On
 
    .. code-block:: text
 
-      docker-compose exec restproxy curl -X GET \
+      docker-compose exec --no-TTY restproxy curl -s -X GET \
          -H "Content-Type: application/json" \
          -H "accept: application/json" \
          --cert /etc/kafka/secrets/mds.certificate.pem \
@@ -1432,7 +1432,7 @@ Before running this section:
 
    .. sourcecode:: bash
 
-      docker-compose exec kafka1 kafka-replica-status \
+      docker exec kafka1 kafka-replica-status \
            --bootstrap-server kafka1:9091 \
            --admin.config /etc/kafka/secrets/client_sasl_plain.config \
            --verbose | grep "IsInIsr: false"

--- a/env_files/config.env
+++ b/env_files/config.env
@@ -5,11 +5,11 @@
 # over time to construct other
 # values required by this repository
 #####################################################
-CONFLUENT=7.1.0-0
-CONFLUENT_DOCKER_TAG=7.1.x-latest
+CONFLUENT=7.1.0
+CONFLUENT_DOCKER_TAG=7.1.0
 CONFLUENT_SHORT=7.1
 CONFLUENT_PREVIOUS=""
-CONFLUENT_RELEASE_TAG_OR_BRANCH=7.1.x
+CONFLUENT_RELEASE_TAG_OR_BRANCH=7.1.0-post
 CONFLUENT_MAJOR=7
 CONFLUENT_MINOR=1
 CONFLUENT_PATCH=0

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -140,7 +140,7 @@ retry $MAX_WAIT host_check_schema_registered || exit 1
 # Register the same schema for the replicated topic wikipedia.parsed.replica as was created for the original topic wikipedia.parsed
 # In this case the replicated topic will register with the same schema ID as the original topic
 echo -e "\nRegister subject wikipedia.parsed.replica-value in Schema Registry"
-SCHEMA=$(docker-compose exec schemaregistry curl -s -X GET --cert /etc/kafka/secrets/schemaregistry.certificate.pem --key /etc/kafka/secrets/schemaregistry.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u superUser:superUser https://schemaregistry:8085/subjects/wikipedia.parsed-value/versions/latest | jq .schema)
+SCHEMA=$(docker-compose exec --no-TTY schemaregistry curl -s -X GET --cert /etc/kafka/secrets/schemaregistry.certificate.pem --key /etc/kafka/secrets/schemaregistry.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u superUser:superUser https://schemaregistry:8085/subjects/wikipedia.parsed-value/versions/latest | jq .schema)
 docker-compose exec schemaregistry curl -X POST --cert /etc/kafka/secrets/schemaregistry.certificate.pem --key /etc/kafka/secrets/schemaregistry.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -H "Content-Type: application/vnd.schemaregistry.v1+json" --data "{\"schema\": $SCHEMA}" -u superUser:superUser https://schemaregistry:8085/subjects/wikipedia.parsed.replica-value/versions
 
 echo


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2720

DEVX-2720: fixes for failed runs on modern docker and docker-compose
I have not been able to isolate why these changes are required on my development machine. However, without these the cp-demo start script failed for a variety of reasons.  The return values from executions of docker-compose exec ... resulted in empty variables which evaluated to various runtime error in the start script. 

This set of changes does not directly address the issues identified in DEVX-2720 but instead was required by me to get the demo to run at all.  I will next attempt to understand and address the issues noted in the Jira issue.'

### Author Validation
- [X] Documentation
- [X] Run cp-demo

### Reviewer Tasks
- [ ] Documentation
- [ ] Run cp-demo
