### PR TITLE
modify gitpod init for better behavior when prebuilds are not available

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,13 +3,13 @@ github:
     # enable for the default branch (defaults to true)
     master: true
     # enable for all branches in this repo (defaults to false)
-    branches: true
+    branches: false
     # enable for pull requests coming from this repo (defaults to true)
     pullRequests: true
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
     addComment: true
     # configure whether Gitpod registers itself as a status check to pull requests
-    addCheck: false
+    addCheck: true
 
 tasks:
   - name: prebuild

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,7 +19,7 @@ tasks:
         echo "ℹ️ AUTOSTART environment variable is set to false, so use ./scripts/start.sh to start cp-demo"
       else
         echo "🚀 Starting up cp-demo (you can disable autostart by exporting environment variable AUTOSTART=false, see https://www.gitpod.io/docs/environment-variables)"
-        CLEAN=true ./scripts/start.sh || exit 1
+        CLEAN=true ./scripts/start.sh || ./scripts/start.sh
         echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
       fi
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,7 +19,7 @@ tasks:
         echo "ℹ️ AUTOSTART environment variable is set to false, so use ./scripts/start.sh to start cp-demo"
       else
         echo "🚀 Starting up cp-demo (you can disable autostart by exporting environment variable AUTOSTART=false, see https://www.gitpod.io/docs/environment-variables)"
-        ./scripts/start.sh || ./scripts/start.sh || exit 1
+        CLEAN=true ./scripts/start.sh || ./scripts/start.sh
         echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
       fi
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,6 +14,7 @@ github:
 tasks:
   - name: cp-demo
     before: |
+      curl -L --http1.1 https://cnfl.io/ccloud-cli | sudo sh -s -- -b /usr/local/bin
       if [[ "$AUTOSTART" =~ "false" ]]; then
         echo "ℹ️ AUTOSTART environment variable is set to false, so use ./scripts/start.sh to start cp-demo"
       else
@@ -21,7 +22,6 @@ tasks:
         CLEAN=true ./scripts/start.sh
         echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
       fi
-    command: curl -L --http1.1 https://cnfl.io/ccloud-cli | sudo sh -s -- -b /usr/local/bin; exit
 
 
 vscode:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,7 +19,7 @@ tasks:
         echo "ℹ️ AUTOSTART environment variable is set to false, so use ./scripts/start.sh to start cp-demo"
       else
         echo "🚀 Starting up cp-demo (you can disable autostart by exporting environment variable AUTOSTART=false, see https://www.gitpod.io/docs/environment-variables)"
-        CLEAN=true ./scripts/start.sh
+        CLEAN=true ./scripts/start.sh || exit 1
         echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
       fi
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,19 +12,17 @@ github:
     addCheck: true
 
 tasks:
-  - name: prebuild
-    init: CLEAN=true ./scripts/start.sh && gp sync-done prebuild
+  - name: cp-demo
+    before: |
+      if [[ "$AUTOSTART" =~ "false" ]]; then
+        echo "ℹ️ AUTOSTART environment variable is set to false, so use ./scripts/start.sh to start cp-demo"
+      else
+        echo "🚀 Starting up cp-demo (you can disable autostart by exporting environment variable AUTOSTART=false, see https://www.gitpod.io/docs/environment-variables)"
+        CLEAN=true ./scripts/start.sh
+        echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
+      fi
     command: curl -L --http1.1 https://cnfl.io/ccloud-cli | sudo sh -s -- -b /usr/local/bin; exit
 
-  - name: cp-demo
-    init: gp sync-await prebuild
-    command: |
-      if [ -z "$DISABLE_AUTOSTART" ]; then
-        echo "🚀 Starting up cp-demo (you can disable autostart by exporting DISABLE_AUTOSTART environment variable, see https://www.gitpod.io/docs/environment-variables)"
-        ./scripts/start.sh
-        echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
-      else echo "ℹ️ DISABLE_AUTOSTART environment variable is set, use ./scripts/start.sh to start cp-demo"
-      fi
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,12 +13,18 @@ github:
 
 tasks:
   - name: prebuild
-    init: ./scripts/start.sh && ./scripts/stop.sh && gp sync-done prebuild
+    init: CLEAN=true ./scripts/start.sh && gp sync-done prebuild
     command: curl -L --http1.1 https://cnfl.io/ccloud-cli | sudo sh -s -- -b /usr/local/bin; exit
 
   - name: cp-demo
     init: gp sync-await prebuild
-    command: if [ -z "$DISABLE_AUTOSTART" ]; then echo "🚀 Starting up cp-demo (you can disable autostart by exporting DISABLE_AUTOSTART environment variable, see https://www.gitpod.io/docs/environment-variables)";./scripts/start.sh; echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"; else echo "ℹ️ DISABLE_AUTOSTART environment variable is set, use ./scripts/start.sh to start cp-demo";fi
+    command: |
+      if [ -z "$DISABLE_AUTOSTART" ]; then
+        echo "🚀 Starting up cp-demo (you can disable autostart by exporting DISABLE_AUTOSTART environment variable, see https://www.gitpod.io/docs/environment-variables)"
+        ./scripts/start.sh
+        echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
+      else echo "ℹ️ DISABLE_AUTOSTART environment variable is set, use ./scripts/start.sh to start cp-demo"
+      fi
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,7 +19,7 @@ tasks:
         echo "ℹ️ AUTOSTART environment variable is set to false, so use ./scripts/start.sh to start cp-demo"
       else
         echo "🚀 Starting up cp-demo (you can disable autostart by exporting environment variable AUTOSTART=false, see https://www.gitpod.io/docs/environment-variables)"
-        CLEAN=true ./scripts/start.sh || ./scripts/start.sh
+        CLEAN=true ./scripts/start.sh || ./scripts/start.sh || exit 1
         echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
       fi
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,7 +19,7 @@ tasks:
         echo "ℹ️ AUTOSTART environment variable is set to false, so use ./scripts/start.sh to start cp-demo"
       else
         echo "🚀 Starting up cp-demo (you can disable autostart by exporting environment variable AUTOSTART=false, see https://www.gitpod.io/docs/environment-variables)"
-        CLEAN=true ./scripts/start.sh || ./scripts/start.sh || exit 1
+        ./scripts/start.sh || ./scripts/start.sh || exit 1
         echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
       fi
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,7 @@ github:
 tasks:
   - name: cp-demo
     before: |
-      curl -L --http1.1 https://cnfl.io/ccloud-cli | sudo sh -s -- -b /usr/local/bin
+      curl -L --http1.1 https://cnfl.io/cli | sudo sh -s -- -b /usr/local/bin
       if [[ "$AUTOSTART" =~ "false" ]]; then
         echo "ℹ️ AUTOSTART environment variable is set to false, so use ./scripts/start.sh to start cp-demo"
       else

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,7 +19,7 @@ tasks:
         echo "ℹ️ AUTOSTART environment variable is set to false, so use ./scripts/start.sh to start cp-demo"
       else
         echo "🚀 Starting up cp-demo (you can disable autostart by exporting environment variable AUTOSTART=false, see https://www.gitpod.io/docs/environment-variables)"
-        CLEAN=true ./scripts/start.sh || ./scripts/start.sh
+        CLEAN=false ./scripts/start.sh || CLEAN=true ./scripts/start.sh || exit 1
         echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
       fi
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -30,12 +30,12 @@ fi
 kibanaURL="http://localhost:5601/app/dashboards#/view/Overview"
 
 # Gitpod only supports the C3_KSQLDB_HTTPS=false scenario and exposes services with a custom URL
-if [[ -n "${GITPOD_WORKSPACE_ID:-}" ]]; then
+if [[ -n "${GITPOD_WORKSPACE_URL:-}" ]]; then
   C3_KSQLDB_HTTPS="false"
   export CONTROL_CENTER_KSQL_WIKIPEDIA_URL="http://ksqldb-server:8088"
-  export CONTROL_CENTER_KSQL_WIKIPEDIA_ADVERTISED_URL="https://8088-${GITPOD_WORKSPACE_ID}"
-  C3URL="https://9021-${GITPOD_WORKSPACE_ID} (port 9022 not supported on Gitpod)"
-  kibanaURL="https://5601-${GITPOD_WORKSPACE_ID}/app/dashboards#/view/Overview"
+  export CONTROL_CENTER_KSQL_WIKIPEDIA_ADVERTISED_URL="https://8088-${GITPOD_WORKSPACE_URL#https://}"
+  C3URL="https://9021-${GITPOD_WORKSPACE_URL#https://} (port 9022 not supported on Gitpod)"
+  kibanaURL="https://5601-${GITPOD_WORKSPACE_URL#https://}/app/dashboards#/view/Overview"
 fi
 
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -26,12 +26,16 @@ else
   C3URL=https://localhost:9022
 fi
 
+# Set Kibana URL
+kibanaURL="http://localhost:5601/app/dashboards#/view/Overview"
+
 # Gitpod only supports the C3_KSQLDB_HTTPS=false scenario and exposes services with a custom URL
-if [[ -n "${GITPOD_WORKSPACE_URL:-}" ]]; then
+if [[ -n "${GITPOD_WORKSPACE_ID:-}" ]]; then
   C3_KSQLDB_HTTPS="false"
   export CONTROL_CENTER_KSQL_WIKIPEDIA_URL="http://ksqldb-server:8088"
-  export CONTROL_CENTER_KSQL_WIKIPEDIA_ADVERTISED_URL="https://8088-${GITPOD_WORKSPACE_URL#https://}"
-  C3URL="https://9021-${GITPOD_WORKSPACE_URL#https://} (port 9022 not supported on Gitpod)"
+  export CONTROL_CENTER_KSQL_WIKIPEDIA_ADVERTISED_URL="https://8088-${GITPOD_WORKSPACE_ID}"
+  C3URL="https://9021-${GITPOD_WORKSPACE_ID} (port 9022 not supported on Gitpod)"
+  kibanaURL="https://5601-${GITPOD_WORKSPACE_ID}/app/dashboards#/view/Overview"
 fi
 
 

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -238,7 +238,7 @@ host_check_ksqlDBserver_up()
 host_check_connect_up()
 {
   containerName=$1
-  FOUND=$(docker-compose logs $containerName | grep "Herder started")
+  FOUND=$(docker-compose logs $containerName | grep "Kafka Connect started")
   if [ -z "$FOUND" ]; then
     return 1
   fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -93,6 +93,11 @@ echo
 echo -e "Create topics in Kafka cluster:"
 docker-compose exec tools bash -c "/tmp/helper/create-topics.sh" || exit 1
 
+# Verify Kafka Connect Worker has started
+MAX_WAIT=240
+echo -e "\nWaiting up to $MAX_WAIT seconds for Connect to start"
+retry $MAX_WAIT host_check_connect_up "connect" || exit 1
+
 # Verify Confluent Control Center has started
 MAX_WAIT=300
 echo
@@ -102,12 +107,6 @@ retry $MAX_WAIT host_check_control_center_up || exit 1
 echo -e "\nConfluent Control Center modifications:"
 ${DIR}/helper/control-center-modifications.sh
 echo
-
-# Verify Kafka Connect Worker has started
-MAX_WAIT=240
-echo -e "\nWaiting up to $MAX_WAIT seconds for Connect to start"
-retry $MAX_WAIT host_check_connect_up "connect" || exit 1
-sleep 10 # give connect an exta moment to fully mature
 
 NUM_CERTS=$(docker-compose exec connect keytool --list --keystore /etc/kafka/secrets/kafka.connect.truststore.jks --storepass confluent | grep trusted | wc -l)
 if [[ "$NUM_CERTS" -eq "1" ]]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -50,14 +50,8 @@ if [[ $(docker-compose ps openldap | grep Exit) =~ "Exit" ]] ; then
   exit 1
 fi
 
-# Build tools image
+# Bring up base cluster and Confluent CLI
 build_tools_image
-# Build custom Kafka Connect image with required jars
-if [[ "$CLEAN" == "true" ]] ; then
-  build_connect_image || exit 1
-fi
-
-# Bring up base cluster
 docker-compose up -d zookeeper kafka1 kafka2 tools
 
 # Verify MDS has started
@@ -81,6 +75,11 @@ docker-compose exec kafka1 kafka-configs \
    --add-config min.insync.replicas=1
 
 #-------------------------------------------------------------------------------
+
+# Build custom Kafka Connect image with required jars
+if [[ "$CLEAN" == "true" ]] ; then
+  build_connect_image || exit 1
+fi
 
 # Bring up more containers
 docker-compose up -d schemaregistry connect control-center

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -56,14 +56,18 @@ if [[ "$CLEAN" == "true" ]] ; then
   build_connect_image || exit 1
 fi
 
-# Bring up base kafka cluster and tools
-docker-compose up -d zookeeper kafka1 kafka2 tools
+# Bring up tools
+docker-compose up -d tools
 
 # Add root CA to container (obviates need for supplying it at CLI login '--ca-cert-path')
 docker-compose exec tools bash -c "cp /etc/kafka/secrets/snakeoil-ca-1.crt /usr/local/share/ca-certificates && /usr/sbin/update-ca-certificates"
 
+
+# Bring up base kafka cluster
+docker-compose up -d zookeeper kafka1 kafka2
+
 # Verify MDS has started
-MAX_WAIT=120
+MAX_WAIT=150
 echo "Waiting up to $MAX_WAIT seconds for MDS to start"
 retry $MAX_WAIT host_check_mds_up || exit 1
 sleep 5

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -97,7 +97,6 @@ docker-compose exec tools bash -c "/tmp/helper/create-topics.sh" || exit 1
 MAX_WAIT=240
 echo -e "\nWaiting up to $MAX_WAIT seconds for Connect to start"
 retry $MAX_WAIT host_check_connect_up "connect" || exit 1
-sleep 20 # give connect a moment to settle
 
 # Verify Confluent Control Center has started
 MAX_WAIT=300

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -50,8 +50,14 @@ if [[ $(docker-compose ps openldap | grep Exit) =~ "Exit" ]] ; then
   exit 1
 fi
 
-# Bring up base cluster and Confluent CLI
+# Build tools image
 build_tools_image
+# Build custom Kafka Connect image with required jars
+if [[ "$CLEAN" == "true" ]] ; then
+  build_connect_image || exit 1
+fi
+
+# Bring up base cluster
 docker-compose up -d zookeeper kafka1 kafka2 tools
 
 # Verify MDS has started
@@ -75,11 +81,6 @@ docker-compose exec kafka1 kafka-configs \
    --add-config min.insync.replicas=1
 
 #-------------------------------------------------------------------------------
-
-# Build custom Kafka Connect image with required jars
-if [[ "$CLEAN" == "true" ]] ; then
-  build_connect_image || exit 1
-fi
 
 # Bring up more containers
 docker-compose up -d schemaregistry connect control-center

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -104,7 +104,7 @@ echo
 MAX_WAIT=240
 echo -e "\nWaiting up to $MAX_WAIT seconds for Connect to start"
 retry $MAX_WAIT host_check_connect_up "connect" || exit 1
-sleep 2 # give connect an exta moment to fully mature
+sleep 5 # give connect an exta moment to fully mature
 
 NUM_CERTS=$(docker-compose exec connect keytool --list --keystore /etc/kafka/secrets/kafka.connect.truststore.jks --storepass confluent | grep trusted | wc -l)
 if [[ "$NUM_CERTS" -eq "1" ]]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -50,18 +50,24 @@ if [[ $(docker-compose ps openldap | grep Exit) =~ "Exit" ]] ; then
   exit 1
 fi
 
-# Bring up base cluster and Confluent CLI
+# Build custom tools image and connect image
 build_tools_image
-docker-compose up -d zookeeper kafka1 kafka2 tools
+if [[ "$CLEAN" == "true" ]] ; then
+  build_connect_image || exit 1
+fi
+
+# Add root CA to container (obviates need for supplying it at CLI login '--ca-cert-path')
+docker-compose up -d tools
+docker-compose exec tools bash -c "cp /etc/kafka/secrets/snakeoil-ca-1.crt /usr/local/share/ca-certificates && /usr/sbin/update-ca-certificates"
+
+# Bring up base kafka cluster
+docker-compose up -d zookeeper kafka1 kafka2
 
 # Verify MDS has started
 MAX_WAIT=120
 echo "Waiting up to $MAX_WAIT seconds for MDS to start"
 retry $MAX_WAIT host_check_mds_up || exit 1
 sleep 5
-
-# Add root CA to container (obviates need for supplying it at CLI login '--ca-cert-path')
-docker-compose exec tools bash -c "cp /etc/kafka/secrets/snakeoil-ca-1.crt /usr/local/share/ca-certificates && /usr/sbin/update-ca-certificates"
 
 echo "Creating role bindings for principals"
 docker-compose exec tools bash -c "/tmp/helper/create-role-bindings.sh" || exit 1
@@ -76,10 +82,6 @@ docker-compose exec kafka1 kafka-configs \
 
 #-------------------------------------------------------------------------------
 
-# Build custom Kafka Connect image with required jars
-if [[ "$CLEAN" == "true" ]] ; then
-  build_connect_image || exit 1
-fi
 
 # Bring up more containers
 docker-compose up -d schemaregistry connect control-center

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -56,12 +56,11 @@ if [[ "$CLEAN" == "true" ]] ; then
   build_connect_image || exit 1
 fi
 
-# Add root CA to container (obviates need for supplying it at CLI login '--ca-cert-path')
-docker-compose up -d tools
-docker-compose exec tools bash -c "cp /etc/kafka/secrets/snakeoil-ca-1.crt /usr/local/share/ca-certificates && /usr/sbin/update-ca-certificates"
+# Bring up base kafka cluster and tools
+docker-compose up -d zookeeper kafka1 kafka2 tools
 
-# Bring up base kafka cluster
-docker-compose up -d zookeeper kafka1 kafka2
+# Add root CA to container (obviates need for supplying it at CLI login '--ca-cert-path')
+docker-compose exec tools bash -c "cp /etc/kafka/secrets/snakeoil-ca-1.crt /usr/local/share/ca-certificates && /usr/sbin/update-ca-certificates"
 
 # Verify MDS has started
 MAX_WAIT=120

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -118,6 +118,10 @@ echo
 docker-compose up -d ksqldb-server ksqldb-cli restproxy
 echo "..."
 
+if [[ "$VIZ" == "true" ]]; then
+  build_viz || exit 1
+fi
+
 # Verify Docker containers started
 if [[ $(docker-compose ps) =~ "Exit 137" ]]; then
   echo -e "\nERROR: At least one Docker container did not start properly, see 'docker-compose ps'. Did you increase the memory available to Docker to at least 8 GB (default is 2 GB)?\n"
@@ -161,6 +165,7 @@ echo
 MAX_WAIT=120
 echo -e "\nWaiting up to $MAX_WAIT seconds for ksqlDB server to start"
 retry $MAX_WAIT host_check_ksqlDBserver_up || exit 1
+
 echo -e "\nRun ksqlDB queries:"
 ${DIR}/ksqlDB/run_ksqlDB.sh
 
@@ -176,9 +181,6 @@ echo "..."
 
 #-------------------------------------------------------------------------------
 
-if [[ "$VIZ" == "true" ]]; then
-  build_viz || exit 1
-fi
 
 echo
 echo -e "\nAvailable LDAP users:"
@@ -186,11 +188,11 @@ echo -e "\nAvailable LDAP users:"
 curl -u mds:mds -X POST "https://localhost:8091/security/1.0/principals/User%3Amds/roles/UserAdmin" \
   -H "accept: application/json" -H "Content-Type: application/json" \
   -d "{\"clusters\":{\"kafka-cluster\":\"does_not_matter\"}}" \
-  --cacert scripts/security/snakeoil-ca-1.crt --tlsv1.2
+  --cacert ${DIR}/security/snakeoil-ca-1.crt --tlsv1.2
 curl -u mds:mds -X POST "https://localhost:8091/security/1.0/rbac/principals" --silent \
   -H "accept: application/json"  -H "Content-Type: application/json" \
   -d "{\"clusters\":{\"kafka-cluster\":\"does_not_matter\"}}" \
-  --cacert scripts/security/snakeoil-ca-1.crt --tlsv1.2 | jq '.[]'
+  --cacert ${DIR}/security/snakeoil-ca-1.crt --tlsv1.2 | jq '.[]'
 
 # Do poststart_checks
 poststart_checks

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -207,7 +207,7 @@ EOF
 if [[ "$VIZ" == "true" ]]; then
 cat << EOF
   Kibana
-     http://localhost:5601/app/dashboards#/view/Overview
+     $kibanaURL
 
 EOF
 fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -97,6 +97,7 @@ docker-compose exec tools bash -c "/tmp/helper/create-topics.sh" || exit 1
 MAX_WAIT=240
 echo -e "\nWaiting up to $MAX_WAIT seconds for Connect to start"
 retry $MAX_WAIT host_check_connect_up "connect" || exit 1
+sleep 20 # give connect a moment to settle
 
 # Verify Confluent Control Center has started
 MAX_WAIT=300

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -107,7 +107,7 @@ echo
 MAX_WAIT=240
 echo -e "\nWaiting up to $MAX_WAIT seconds for Connect to start"
 retry $MAX_WAIT host_check_connect_up "connect" || exit 1
-sleep 5 # give connect an exta moment to fully mature
+sleep 10 # give connect an exta moment to fully mature
 
 NUM_CERTS=$(docker-compose exec connect keytool --list --keystore /etc/kafka/secrets/kafka.connect.truststore.jks --storepass confluent | grep trusted | wc -l)
 if [[ "$NUM_CERTS" -eq "1" ]]; then

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../env_files/config.env
 source ${DIR}/env.sh
 
-docker-compose down --volumes
+docker-compose down --volumes --remove-orphans
 
 cat << EOF
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../env_files/config.env
 source ${DIR}/env.sh
 
-docker-compose down --volumes --remove-orphans
+docker-compose down --volumes
 
 cat << EOF
 


### PR DESCRIPTION
### Description 

_What behavior does this PR change, and why?_

Right now, the `init` step in gitpod starts and stops cp demo. If a prebuild isn't available, that means users will experience start, stop, and start again.

Other improvements that may be in scope:
- limit the number of prebuilds that run to only the default branch and PRs.
- add prebuilds as a status check to PRs to act as some light CI / automated validation 
- fix transient issue where zookeeper gets confused after restart and brokers barf
- fix issue where connect isn't ready in time (more of a hack, but a proper fix is out of scope)

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation
- [x] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation
- [ ] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->
