### PR TITLE
set VIZ=false for gitpod due to resources

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,7 +20,7 @@ tasks:
         echo "ℹ️ AUTOSTART environment variable is set to false, so use ./scripts/start.sh to start cp-demo"
       else
         echo "🚀 Starting up cp-demo (you can disable autostart by exporting environment variable AUTOSTART=false, see https://www.gitpod.io/docs/environment-variables)"
-        CLEAN=false ./scripts/start.sh || CLEAN=true ./scripts/start.sh || exit 1
+        CLEAN=false VIZ=false ./scripts/start.sh || CLEAN=true VIZ=false ./scripts/start.sh || exit 1
         echo "🚀 You can now follow steps in https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/on-prem.html#guided-tutorial"
       fi
 


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_

As of right now, CP Demo is too CPU intensive for gitpod. It seems to work well before elasticsearch and kibana are created. The hope is that setting VIZ=false will make gitpod useable with CP Demo.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation
- [ ] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation
- [ ] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->
