### PR TITLE
cp-demo-kstreams rebuild from fresh base

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1005,7 +1005,7 @@ services:
 
 
   streams-demo:
-    image: cnfldemos/cp-demo-kstreams:0.0.10
+    image: cnfldemos/cp-demo-kstreams:0.0.11
     restart: always
     depends_on:
       schemaregistry:

--- a/kstreams-app/build.gradle
+++ b/kstreams-app/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = 'io.confluent'
-version = '0.0.10'
+version = '0.0.11'
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
@@ -22,7 +22,7 @@ def props = new Properties()
 file("../env_files/config.env").withInputStream { props.load(it) }
 
 ext {
-  cpVersion = props.getProperty("CONFLUENT") ?: '6.2.0'
+  cpVersion = props.getProperty("CONFLUENT") ?: '7.3.2'
 }
 
 repositories {


### PR DESCRIPTION
### Description 


_What behavior does this PR change, and why?_

Forces rebuild and new version of `cp-demo-streams` with a fresh CP 7.3.2 base image.  This will align 11.0 JDK versions and solve a `NoSuchAlgorithmException: Algorithm HmacPBESHA256 not available` problem.

Fixes #438 .

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [X] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
