### PR TITLE
Grant ksqlDBUser ResourceOwner on source topics (CP 7.4 RBAC)

### DIFF
--- a/scripts/helper/create-role-bindings.sh
+++ b/scripts/helper/create-role-bindings.sh
@@ -242,7 +242,7 @@ confluent iam rbac role-binding create \
 
 confluent iam rbac role-binding create \
     --principal $KSQLDB_ADMIN \
-    --role DeveloperRead \
+    --role ResourceOwner \
     --resource Topic:wikipedia.parsed \
     --kafka-cluster-id $KAFKA_CLUSTER_ID
 
@@ -330,7 +330,7 @@ confluent iam rbac role-binding create \
 
 confluent iam rbac role-binding create \
     --principal $KSQLDB_USER \
-    --role DeveloperRead \
+    --role ResourceOwner \
     --resource Topic:wikipedia.parsed \
     --kafka-cluster-id $KAFKA_CLUSTER_ID
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/TMM-84

With Confluent Platform 7.4, `ksqlDBUser` now requires `ResourceOwner` privilege on source topics.  This was `DeveloperRead` previously.

Without this, this error will be seen:

```
Authorization denied to Describe_configs on topic(s): []
```

_What behavior does this PR change, and why?_

`ksqlDBUser` now has `ResourceOwner` on two topics.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation
- [X] Run cp-demo
- [ ] jmx-monitoring-stacks


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
