### PR TITLE
Hybrid cloud docs fixes

### DIFF
--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -136,7 +136,7 @@ Set Up Confluent CLI and variables
          --schema-registry-cluster $CC_SR_CLUSTER_ID \
          --resource 'Subject:*'
 
-   Verify the role-binding has been created by running:
+   Verify the role binding has been created by running:
 
    .. code:: shell
 

--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -125,6 +125,26 @@ Set Up Confluent CLI and variables
       && echo "Schema Registry Cluster ID: $CC_SR_CLUSTER_ID" \
       && echo "Schema Registry Endpoint: $CC_SR_ENDPOINT"
 
+#. Grant the ``ResourceOwner`` role to the cp-demo service account for all Schema subjects.
+
+   .. code:: shell
+
+      confluent iam rbac role-binding create \
+         --role ResourceOwner \
+         --principal User:$SERVICE_ACCOUNT_ID \
+         --current-environment \
+         --schema-registry-cluster $CC_SR_CLUSTER_ID \
+         --resource 'Subject:*'
+
+   Verify the role-binding has been created by running:
+
+   .. code:: shell
+
+      confluent iam rbac role-binding list \
+          --principal User:$SERVICE_ACCOUNT_ID \
+          --current-environment \
+          --schema-registry-cluster $CC_SR_CLUSTER_ID \
+          --resource 'Subject:*'
 
 #. Create a Schema Registry API key for the cp-demo service account.
 

--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -134,7 +134,7 @@ Set Up Confluent CLI and variables
          --principal User:$SERVICE_ACCOUNT_ID \
          --current-environment \
          --schema-registry-cluster $CC_SR_CLUSTER_ID \
-         --resource 'Subject:*'
+         --resource "Subject:*"
 
    Verify the role binding has been created by running:
 

--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -391,8 +391,9 @@ mirror Kafka topics from your on-premises cluster to |ccloud|.
 
       confluent iam rbac role-binding list \
          --principal User:$SERVICE_ACCOUNT_ID \
+         --cloud-cluster $CCLOUD_CLUSTER_ID \
+         --environment $CC_ENV \
          -o json | jq
-
 
 #. Inspect the file ``scripts/ccloud/cluster-link-ccloud.properties``
 

--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -144,7 +144,7 @@ Set Up Confluent CLI and variables
           --principal User:$SERVICE_ACCOUNT_ID \
           --current-environment \
           --schema-registry-cluster $CC_SR_CLUSTER_ID \
-          --resource 'Subject:*'
+          --resource "Subject:*"
 
 #. Create a Schema Registry API key for the cp-demo service account.
 

--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -127,7 +127,7 @@ Set Up Confluent CLI and variables
 
 #. Grant the ``ResourceOwner`` role to the cp-demo service account for all Schema subjects.
 
-   .. code:: shell
+   .. code:: text
 
       confluent iam rbac role-binding create \
          --role ResourceOwner \


### PR DESCRIPTION
### Description 

Two fixes for cp-demo docs.

- Adds `ResourceOwner` role-binding required for the cp-demo service account to run Schema Linking.
- Fixes cluster/environment qualification on one role-binding list command.

**Staging Server URL:** http://staging-docs-independent.confluent.io.s3-website-us-west-2.amazonaws.com/docs-platform/PR/2937/7.5/tutorials/cp-demo/docs/hybrid-cloud.html
