### PR TITLE
feat(): enable confluent.consumer.lag.emitter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -269,6 +269,9 @@ services:
       # Encrypt credentials stored in Cluster Link
       KAFKA_PASSWORD_ENCODER_SECRET: encoder-secret
 
+      # Enable Consumer Lag emitter
+      KAFKA_CONFLUENT_CONSUMER_LAG_EMITTER_ENABLED: 'true'
+
   kafka2:
     image: ${REPOSITORY}/cp-server:${CONFLUENT_DOCKER_TAG}
     hostname: kafka2
@@ -453,6 +456,8 @@ services:
       # Encrypt credentials stored in Cluster Link
       KAFKA_PASSWORD_ENCODER_SECRET: encoder-secret
 
+      # Enable Consumer Lag emitter
+      KAFKA_CONFLUENT_CONSUMER_LAG_EMITTER_ENABLED: 'true'
 
         
   connect:


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_

Since CP 7.5, we can emit consumer lag via the configuration confluent.consumer.lag.emitter.enabled, see https://docs.confluent.io/platform/current/monitor/monitor-consumer-lag.html#monitor-consumer-lag

To use this functionality in the [jmx-monitoring-stacks](https://github.com/confluentinc/jmx-monitoring-stacks) repository, we first need to enable it in cp-demo.


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
