### PR TITLE
DEVX-2804 - Move RST docs to docs-platform

### DIFF
--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -654,6 +654,6 @@ Query Metrics
 Cleanup
 -------
 
-.. include:: ../../includes/ccloud-examples-terminate.rst
+.. include:: ../../../includes/ccloud-examples-terminate.rst
 
 Follow the clean up procedure in :ref:`cp-demo-ccloud-cleanup` to avoid unexpected |ccloud| charges.

--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -10,8 +10,8 @@ Hybrid Deployment to |ccloud|
 In a hybrid |ak-tm| deployment scenario, you can have both an on-premises |cp| deployment as well as a
 `Confluent Cloud <https://confluent.cloud>`__ deployment.
 In this module, you will use `Cluster Linking <https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/index.html>`__
-and `Schema Linking <https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html>`__ to send data and schemas to
-|ccloud|, and monitor both deployments with `Confluent Health+ <https://docs.confluent.io/platform/current/health-plus/index.html#confluent-health>`__ and the `Confluent Cloud Metrics API <https://docs.confluent.io/cloud/current/monitoring/metrics-api.html>`__.
+and :platform:`Schema Linking|schema-registry/schema-linking-cp.html` to send data and schemas to
+|ccloud|, and monitor both deployments with :platform:`Confluent Health+|health-plus/index.html#confluent-health` and the `Confluent Cloud Metrics API <https://docs.confluent.io/cloud/current/monitoring/metrics-api.html>`__.
 
 .. figure:: images/cp-demo-overview-with-ccloud.svg
     :alt: image
@@ -25,7 +25,7 @@ Cost to Run
 Caution
 ~~~~~~~
 
-.. include:: ../../examples/ccloud/docs/includes/ccloud-examples-caution.rst
+.. include:: ../../../includes/ccloud-examples-caution.rst
 
 |ccloud| Promo Code
 ~~~~~~~~~~~~~~~~~~~
@@ -206,11 +206,11 @@ Export Schemas to |ccloud| with Schema Linking
 ----------------------------------------------
 
 Confluent Schema Registry is critical for evolving schemas alongside your business needs and ensuring high data quality.
-With `Schema Linking <https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html>`__
+With :platform:`Schema Linking|schema-registry/schema-linking-cp.html`
 , you can easily export your schemas from your on-premises Schema Registry to |ccloud|.
 In this section, you will export the schema subjects ``wikipedia.parsed-value`` and ``wikipedia.parsed.count-by-domain-value``
 from |cp| to |ccloud| with schema linking.
-These schema subjects will be exported to a new `schema context <https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html#what-is-a-schema-context>`__
+These schema subjects will be exported to a new :platform:`schema context|schema-registry/schema-linking-cp.html#what-is-a-schema-context`
 called "cp-demo", so their qualified subject names in |ccloud| will be ``:.cp-demo:wikipedia.parsed-value`` and ``:.cp-demo:wikipedia.parsed.count-by-domain-value``.
 
 

--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -654,6 +654,6 @@ Query Metrics
 Cleanup
 -------
 
-.. include:: ../../examples/ccloud/docs/includes/ccloud-examples-terminate.rst
+.. include:: ../../includes/ccloud-examples-terminate.rst
 
 Follow the clean up procedure in :ref:`cp-demo-ccloud-cleanup` to avoid unexpected |ccloud| charges.

--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -25,7 +25,7 @@ Cost to Run
 Caution
 ~~~~~~~
 
-.. include:: ../../../includes/ccloud-examples-caution.rst
+.. include:: ../../includes/ccloud-examples-caution.rst
 
 |ccloud| Promo Code
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/hybrid-cloud.rst
+++ b/docs/hybrid-cloud.rst
@@ -25,7 +25,7 @@ Cost to Run
 Caution
 ~~~~~~~
 
-.. include:: ../../includes/ccloud-examples-caution.rst
+.. include:: ../../../includes/ccloud-examples-caution.rst
 
 |ccloud| Promo Code
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/includes/metrics-api-intro.rst
+++ b/docs/includes/metrics-api-intro.rst
@@ -9,7 +9,7 @@ You can use the Metrics API to get telemetry data for both the on-premises Confl
 - See the `Confluent Cloud Metrics API Reference <https://api.telemetry.confluent.cloud/docs>`__ for more information.
 
 
-The Metrics API and Telemetry Reporter powers `Health+ <https://docs.confluent.io/platform/current/health-plus/index.html>`__, the fully-managed monitoring
+The Metrics API and Telemetry Reporter powers :platform:`Health+|health-plus/index.html`, the fully-managed monitoring
 solution for Confluent Platform. You can enable Health+ for free and add premium capabilities as you see fit.
 
 Popular `third-party monitoring tools <https://docs.confluent.io/cloud/current/monitoring/metrics-api.html#integrate-with-third-party-monitoring>`__

--- a/docs/on-prem.rst
+++ b/docs/on-prem.rst
@@ -101,7 +101,7 @@ You can run it with optional settings:
 
       CLEAN=true ./scripts/start.sh
 
-#. ``cp-demo`` supports access to the |c3| GUI via either ``http://`` (the default) or secure ``https://``, the latter employing a self-signed CA and certificates generated during deployment. In order to run ksqlDB queries from |c3| later in this tutorial, both ksqlDB and |c3| must be running in either ``http`` or ``https`` `mode <https://docs.confluent.io/platform/current/ksqldb/integrate-ksql-with-confluent-control-center.html#configuration-settings-for-ksqldb-and-c3-short>`__. To run ``cp-demo`` in ``https`` mode, set ``C3_KSQLDB_HTTPS=true`` when starting ``cp-demo``:
+#. ``cp-demo`` supports access to the |c3| GUI via either ``http://`` (the default) or secure ``https://``, the latter employing a self-signed CA and certificates generated during deployment. In order to run ksqlDB queries from |c3| later in this tutorial, both ksqlDB and |c3| must be running in either ``http`` or ``https`` :platform:`mode|ksqldb/integrate-ksql-with-confluent-control-center.html#configuration-settings-for-ksqldb-and-c3-short`. To run ``cp-demo`` in ``https`` mode, set ``C3_KSQLDB_HTTPS=true`` when starting ``cp-demo``:
 
    .. sourcecode:: bash
 
@@ -373,7 +373,7 @@ Consumers
 
 #. |c3| enables you to monitor consumer lag and throughput performance. Consumer lag is the topic's high water mark (latest offset for the topic that has been written) minus the current consumer offset (latest offset read for that topic by that consumer group). Keep in mind the topic's write rate and consumer group's read rate when you consider the significance the consumer lag's size. Click on "Consumers".
 
-#. Consumer lag is available on a `per-consumer basis <https://docs.confluent.io/platform/current/control-center/consumers.html#view-consumer-lag-details-for-a-consumer-group>`__, including the embedded Connect consumers for sink connectors (e.g., ``connect-elasticsearch-ksqldb``), ksqlDB queries (e.g., consumer groups whose names start with ``_confluent-ksql-ksql-clusterquery_``), console consumers (e.g., ``WIKIPEDIANOBOT-consumer``), etc.  Consumer lag is also available on a `per-topic basis <https://docs.confluent.io/platform/current/control-center/topics/view.html#view-consumer-lag-for-a-topic>`__.
+#. Consumer lag is available on a :platform:`per-consumer basis|control-center/consumers.html#view-consumer-lag-details-for-a-consumer-group`, including the embedded Connect consumers for sink connectors (e.g., ``connect-elasticsearch-ksqldb``), ksqlDB queries (e.g., consumer groups whose names start with ``_confluent-ksql-ksql-clusterquery_``), console consumers (e.g., ``WIKIPEDIANOBOT-consumer``), etc.  Consumer lag is also available on a :platform:`per-topic basis|control-center/topics/view.html#view-consumer-lag-for-a-topic`.
 
    .. figure:: images/consumer_group_list.png
       :alt: image
@@ -388,7 +388,7 @@ Consumers
    .. figure:: images/activity-monitor-consumer.png
       :alt: image
 
-#. Consumption metrics are available on a `per-consumer basis <https://docs.confluent.io/platform/current/control-center/consumers.html#view-consumption-details-for-a-consumer-group>`__. These consumption charts are only populated if `Confluent Monitoring Interceptors <https://docs.confluent.io/platform/current/control-center/installation/clients.html>`__ are configured, as they are in this example. You can view ``% messages consumed`` and ``end-to-end latency``.  View consumption metrics for the persistent ksqlDB "Create Stream As Select" query ``CSAS_WIKIPEDIABOT``, which is displayed as ``_confluent-ksql-ksql-clusterquery_CSAS_WIKIPEDIABOT_5`` in the consumer group list.
+#. Consumption metrics are available on a :platform:`per-consumer basis|control-center/consumers.html#view-consumption-details-for-a-consumer-group`. These consumption charts are only populated if :platform:`Confluent Monitoring Interceptors|control-center/installation/clients.html` are configured, as they are in this example. You can view ``% messages consumed`` and ``end-to-end latency``.  View consumption metrics for the persistent ksqlDB "Create Stream As Select" query ``CSAS_WIKIPEDIABOT``, which is displayed as ``_confluent-ksql-ksql-clusterquery_CSAS_WIKIPEDIABOT_5`` in the consumer group list.
 
    .. figure:: images/ksql_query_CSAS_WIKIPEDIABOT_consumption.png
       :alt: image
@@ -495,7 +495,7 @@ End clients (non-CP clients):
 - If they are also using Confluent Monitoring interceptors, authenticate using mTLS via the broker SSL listener.
 -   Should never use the TOKEN listener which is meant only for internal communication between Confluent components.
 
-  - If you wish to authenticate clients with username and password via LDAP, you would create a new SASL PLAIN client listener with Confluent's `LdapAuthenticateCallbackHandler <https://docs.confluent.io/platform/current/kafka/authentication_sasl/client-authentication-ldap.html>`__. This is omitted from the demo for simplicity.
+  - If you wish to authenticate clients with username and password via LDAP, you would create a new SASL PLAIN client listener with Confluent's :platform:`LdapAuthenticateCallbackHandler|kafka/authentication_sasl/client-authentication-ldap.html`. This is omitted from the demo for simplicity.
 
 - See :devx-cp-demo:`client configuration|env_files/streams-demo.env/` used in the example by the ``streams-demo`` container running the |kstreams| application ``wikipedia-activity-monitor``.
 

--- a/docs/teardown.rst
+++ b/docs/teardown.rst
@@ -30,7 +30,7 @@ Stop the |ccloud| Environment
 
 If you ran the :ref:`cp-demo-hybrid` portion of this tutorial, which included creating resources in |ccloud|, follow the clean up procedure below to avoid unexpected |ccloud| charges.
 
-.. include:: ../../examples/ccloud/docs/includes/ccloud-examples-terminate.rst
+.. include:: ../../includes/ccloud-examples-terminate.rst
 
 #. Make sure that you're still using the ``ccloud`` CLI context.
 

--- a/docs/teardown.rst
+++ b/docs/teardown.rst
@@ -30,7 +30,7 @@ Stop the |ccloud| Environment
 
 If you ran the :ref:`cp-demo-hybrid` portion of this tutorial, which included creating resources in |ccloud|, follow the clean up procedure below to avoid unexpected |ccloud| charges.
 
-.. include:: ../../includes/ccloud-examples-terminate.rst
+.. include:: ../../../includes/ccloud-examples-terminate.rst
 
 #. Make sure that you're still using the ``ccloud`` CLI context.
 


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2804

_What behavior does this PR change, and why?_
This PR moves the RST content over to https://github.com/confluentinc/docs-platform/pull/3439 directly. This will greatly simplify the docs build pipeline and resolve longstanding issues around maintenance. 


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
