### PR TITLE
adding secret registry path in cub_classpath

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -475,7 +475,7 @@ services:
     ports:
       - 8083:8083
     environment:
-      CUB_CLASSPATH: '/usr/share/java/confluent-security/connect/*:/usr/share/java/kafka/*:/usr/share/java/cp-base-new/*'
+      CUB_CLASSPATH: '/usr/share/java/confluent-security/connect/*:/usr/share/java/kafka/*:/usr/share/java/cp-base-new/*:/usr/share/java/confluent-secret-registry/*'
 
       CONNECT_BOOTSTRAP_SERVERS: kafka1:10091,kafka2:10092
       CONNECT_LISTENERS: https://0.0.0.0:8083


### PR DESCRIPTION
In CP 7.7 the location of secret registry jars has changed, these will already be included in connect's classpath, but need to be added in cub_classpath for the docker image to startup when secret-registry is configured.
