### PR TITLE
chore: use Compose built into Docker rather than standalone docker-compose

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,11 +16,10 @@ Validate every step in the troubleshooting section: https://docs.confluent.io/pl
 Identify any existing issues that seem related: https://github.com/confluentinc/cp-demo/issues?q=is%3Aissue
 
 If applicable, please include the output of:
- - `docker-compose logs <container name>`
+ - `docker compose logs <container name>`
  - any other relevant commands
 
 **Environment**
  - GitHub branch: [e.g. `6.0.1-post`, etc]
  - Operating System:
  - Version of Docker:
- - Version of Docker Compose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
-# docker-compose supports environment variable substitution with the ${VARIABLE-NAME} syntax.
+# Docker Compose supports environment variable substitution with the ${VARIABLE-NAME} syntax.
 # Environment variables can be sourced in a variety of ways.  One of those ways is through
 # a well known '.env' file located in the same folder as the docker-compose.yml file.  See the Docker
 # documentation for details: https://docs.docker.com/compose/environment-variables/#the-env-file
 # 
 # This feature is being used to parameterize some values within this file.  In this directory is also
 # a .env file, which is actually a symbolic link to <examples-root>/utils/config.env.  That file
-# contains values which get substituted here when docker-compose parses this file.
+# contains values which get substituted here when Docker Compose parses this file.
 #
 # If you'd like to view the docker-compose.yml file rendered with its environment variable substitutions
-# you can execute the `docker-compose config` command.  Take note that some demos provide additional 
-# environment variable values by exporting them in a script prior to running `docker-compose up`.
+# you can execute the `docker compose config` command.  Take note that some demos provide additional 
+# environment variable values by exporting them in a script prior to running `docker compose up`.
 ---
 services:
 
@@ -93,7 +93,7 @@ services:
       - ./scripts/security/keypair:/tmp/conf
       - ./scripts/helper:/tmp/helper
       - ./scripts/security:/etc/kafka/secrets
-    command: "bash -c 'if [ ! -f /etc/kafka/secrets/kafka.kafka1.keystore.jks ]; then echo \"ERROR: Did not find SSL certificates in /etc/kafka/secrets/ (did you remember to run ./scripts/start.sh instead of docker-compose up -d?)\" && exit 1 ; else /etc/confluent/docker/run ; fi'"
+    command: "bash -c 'if [ ! -f /etc/kafka/secrets/kafka.kafka1.keystore.jks ]; then echo \"ERROR: Did not find SSL certificates in /etc/kafka/secrets/ (did you remember to run ./scripts/start.sh instead of docker compose up -d?)\" && exit 1 ; else /etc/confluent/docker/run ; fi'"
     ports:
       - 8091:8091
       - 9091:9091
@@ -287,7 +287,7 @@ services:
       - ./scripts/security/keypair:/tmp/conf
       - ./scripts/helper:/tmp/helper
       - ./scripts/security:/etc/kafka/secrets
-    command: "bash -c 'if [ ! -f /etc/kafka/secrets/kafka.kafka2.keystore.jks ]; then echo \"ERROR: Did not find SSL certificates in /etc/kafka/secrets/ (did you remember to run ./scripts/start.sh instead of docker-compose up -d?)\" && exit 1 ; else /etc/confluent/docker/run ; fi'"
+    command: "bash -c 'if [ ! -f /etc/kafka/secrets/kafka.kafka2.keystore.jks ]; then echo \"ERROR: Did not find SSL certificates in /etc/kafka/secrets/ (did you remember to run ./scripts/start.sh instead of docker compose up -d?)\" && exit 1 ; else /etc/confluent/docker/run ; fi'"
     ports:
       - 8092:8092
       - 9092:9092

--- a/scripts/app/throttle_consumer.sh
+++ b/scripts/app/throttle_consumer.sh
@@ -18,11 +18,11 @@ fi
 
 CONSUMER_GROUP="app"
 
-echo "docker-compose exec kafka1 kafka-configs --bootstrap-server kafka1:12091 --entity-type clients --entity-name consumer_app_$ID --alter $CONFIG"
-docker-compose exec kafka1 bash -c "kafka-configs --bootstrap-server kafka1:12091 --entity-type clients --entity-name consumer_app_$ID --alter $CONFIG"
+echo "docker compose exec kafka1 kafka-configs --bootstrap-server kafka1:12091 --entity-type clients --entity-name consumer_app_$ID --alter $CONFIG"
+docker compose exec kafka1 bash -c "kafka-configs --bootstrap-server kafka1:12091 --entity-type clients --entity-name consumer_app_$ID --alter $CONFIG"
 
-echo "docker-compose exec kafka1 kafka-configs --bootstrap-server kafka1:12091 --entity-type clients --describe"
-docker-compose exec kafka1 bash -c 'kafka-configs --bootstrap-server kafka1:12091 --entity-type clients --describe'
+echo "docker compose exec kafka1 kafka-configs --bootstrap-server kafka1:12091 --entity-type clients --describe"
+docker compose exec kafka1 bash -c 'kafka-configs --bootstrap-server kafka1:12091 --entity-type clients --describe'
 
-echo "docker-compose exec kafka1 kafka-consumer-groups --bootstrap-server kafka1:12091 --describe --group $CONSUMER_GROUP"
-docker-compose exec kafka1 kafka-consumer-groups --bootstrap-server kafka1:12091 --describe --group $CONSUMER_GROUP
+echo "docker compose exec kafka1 kafka-consumer-groups --bootstrap-server kafka1:12091 --describe --group $CONSUMER_GROUP"
+docker compose exec kafka1 kafka-consumer-groups --bootstrap-server kafka1:12091 --describe --group $CONSUMER_GROUP

--- a/scripts/ccloud/cluster-link-scratch.sh
+++ b/scripts/ccloud/cluster-link-scratch.sh
@@ -88,7 +88,7 @@ confluent api-key create --service-account $SERVICE_ACCOUNT_ID --resource $CC_SR
 # Create schema exporter aka schema link on the CP side
 # schema linking with confluent CLI not supported for CP yet
 # confluent schema-registry exporter create <exporter-name> --subjects ":*:" --config-file ~/config.txt
-docker-compose exec schemaregistry \
+docker compose exec schemaregistry \
   schema-exporter --create --name cp-cc-schema-exporter --subjects ":wikipedia*:" \
     --config-file /tmp/schema-link.properties \
     --schema.registry.url  https://schemaregistry:8085/

--- a/scripts/ccloud/create-ccloud-workflow.sh
+++ b/scripts/ccloud/create-ccloud-workflow.sh
@@ -42,7 +42,7 @@ sleep 90
 # KAFKA_CLUSTER_ID=$(curl -s https://localhost:8091/v1/metadata/id --tlsv1.2 --cacert ${VALIDATE_DIR}/../security/snakeoil-ca-1.crt | jq -r ".id")
 # CONNECT=connect-cluster
 # ${VALIDATE_DIR}/../helper/refresh_mds_login.sh
-# docker-compose exec tools bash -c "confluent iam rbac role-binding create \
+# docker compose exec tools bash -c "confluent iam rbac role-binding create \
 #     --principal $CONNECTOR_SUBMITTER \
 #     --role ResourceOwner \
 #     --resource Connector:replicate-topic-to-ccloud \
@@ -67,7 +67,7 @@ export METRICS_API_SECRET=$(echo "$CREDENTIALS" | jq -r .secret)
 # Enable Confluent Telemetry Reporter
 echo
 echo "Enabling Confluent Telemetry Reporter cluster-wide to send metrics to Confluent Cloud"
-docker-compose exec kafka1 kafka-configs \
+docker compose exec kafka1 kafka-configs \
   --bootstrap-server kafka1:12091 \
   --alter \
   --entity-type brokers \
@@ -80,8 +80,8 @@ sleep 90
 
 # Query Metrics API
 
-CURRENT_TIME_MINUS_1HR=$(docker-compose exec tools date -Is -d '-1 hour' | tr -d '\r')
-CURRENT_TIME_PLUS_1HR=$(docker-compose exec tools date -Is -d '+1 hour' | tr -d '\r')
+CURRENT_TIME_MINUS_1HR=$(docker compose exec tools date -Is -d '-1 hour' | tr -d '\r')
+CURRENT_TIME_PLUS_1HR=$(docker compose exec tools date -Is -d '+1 hour' | tr -d '\r')
 echo
 echo "CURRENT_TIME_MINUS_1HR=$CURRENT_TIME_MINUS_1HR"
 echo "CURRENT_TIME_PLUS_1HR=$CURRENT_TIME_PLUS_1HR"

--- a/scripts/ccloud/destroy-ccloud-workflow.sh
+++ b/scripts/ccloud/destroy-ccloud-workflow.sh
@@ -38,10 +38,10 @@ fi
 
 ## TODO delete CP cluster link
 # echo "Deleting Cluster Link to Confluent Cloud"
-# docker-compose exec connect curl -XDELETE --cert /etc/kafka/secrets/connect.certificate.pem --key /etc/kafka/secrets/connect.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u connectorSubmitter:connectorSubmitter https://connect:8083/connectors/replicate-topic-to-ccloud
+# docker compose exec connect curl -XDELETE --cert /etc/kafka/secrets/connect.certificate.pem --key /etc/kafka/secrets/connect.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u connectorSubmitter:connectorSubmitter https://connect:8083/connectors/replicate-topic-to-ccloud
 
 echo "Unconfiguring Telemetry Reporter"
-docker-compose exec kafka1 kafka-configs \
+docker compose exec kafka1 kafka-configs \
   --bootstrap-server kafka1:12091 \
   --alter \
   --entity-type brokers \

--- a/scripts/connectors/stop_elasticsearch_sink.sh
+++ b/scripts/connectors/stop_elasticsearch_sink.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose exec connect curl -X DELETE --cert /etc/kafka/secrets/connect.certificate.pem --key /etc/kafka/secrets/connect.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt  https://connect:8083/connectors/elasticsearch
+docker compose exec connect curl -X DELETE --cert /etc/kafka/secrets/connect.certificate.pem --key /etc/kafka/secrets/connect.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt  https://connect:8083/connectors/elasticsearch

--- a/scripts/connectors/submit_elastic_sink_config.sh
+++ b/scripts/connectors/submit_elastic_sink_config.sh
@@ -27,4 +27,4 @@ DATA=$( cat << EOF
 EOF
 )
 
-docker-compose exec connect curl -X POST -H "${HEADER}" --data "${DATA}" --cert /etc/kafka/secrets/connect.certificate.pem --key /etc/kafka/secrets/connect.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u connectorSubmitter:connectorSubmitter https://connect:8083/connectors || exit 1
+docker compose exec connect curl -X POST -H "${HEADER}" --data "${DATA}" --cert /etc/kafka/secrets/connect.certificate.pem --key /etc/kafka/secrets/connect.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u connectorSubmitter:connectorSubmitter https://connect:8083/connectors || exit 1

--- a/scripts/connectors/submit_wikipedia_sse_config.sh
+++ b/scripts/connectors/submit_wikipedia_sse_config.sh
@@ -30,4 +30,4 @@ DATA=$( cat << EOF
 EOF
 )
 
-docker-compose exec connect curl -X POST -H "${HEADER}" --data "${DATA}" --cert /etc/kafka/secrets/connect.certificate.pem --key /etc/kafka/secrets/connect.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u connectorSubmitter:connectorSubmitter https://connect:8083/connectors || exit 1
+docker compose exec connect curl -X POST -H "${HEADER}" --data "${DATA}" --cert /etc/kafka/secrets/connect.certificate.pem --key /etc/kafka/secrets/connect.key --tlsv1.2 --cacert /etc/kafka/secrets/snakeoil-ca-1.crt -u connectorSubmitter:connectorSubmitter https://connect:8083/connectors || exit 1

--- a/scripts/helper/functions.sh
+++ b/scripts/helper/functions.sh
@@ -38,7 +38,7 @@ verify_installed()
 preflight_checks()
 {
   # Verify appropriate tools are installed on host
-  for cmd in curl jq docker-compose keytool docker openssl xargs awk; do
+  for cmd in curl jq keytool docker openssl xargs awk; do
     verify_installed $cmd || exit 1
   done
 
@@ -68,7 +68,7 @@ preflight_checks()
 poststart_checks()
 {
   # Verify no containers have Exited
-  if [[ $(docker-compose ps | grep Exit) ]]; then
+  if [[ $(docker compose ps | grep Exit) ]]; then
     echo -e "\nWARNING: at least one Docker container unexpectedly exited. Please troubleshoot, see https://docs.confluent.io/platform/current/tutorials/cp-demo/docs/troubleshooting.html"
   fi
 
@@ -192,7 +192,7 @@ build_viz()
   echo
   echo "VIZ=true: running Elasticsearch, Elasticsearch sink connector, and Kibana"
 
-  docker-compose up --no-recreate -d elasticsearch kibana
+  docker compose up --no-recreate -d elasticsearch kibana
 
   # Verify Elasticsearch is ready
   MAX_WAIT=240

--- a/scripts/helper/refresh_mds_login.sh
+++ b/scripts/helper/refresh_mds_login.sh
@@ -6,4 +6,4 @@ MDS_URL=https://kafka1:8091
 SUPER_USER=superUser
 SUPER_USER_PASSWORD=superUser
 
-docker-compose exec tools bash -c ". /tmp/helper/functions.sh ; mds_login $MDS_URL ${SUPER_USER} ${SUPER_USER_PASSWORD}"
+docker compose exec tools bash -c ". /tmp/helper/functions.sh ; mds_login $MDS_URL ${SUPER_USER} ${SUPER_USER_PASSWORD}"

--- a/scripts/ksqlDB/run_ksqlDB.sh
+++ b/scripts/ksqlDB/run_ksqlDB.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose exec ksqldb-cli bash -c "ksql -u ksqlDBUser -p ksqlDBUser http://ksqldb-server:8088 <<EOF
+docker compose exec ksqldb-cli bash -c "ksql -u ksqlDBUser -p ksqlDBUser http://ksqldb-server:8088 <<EOF
 RUN SCRIPT '/tmp/statements.sql';
 exit ;
 EOF

--- a/scripts/sbc/add-broker.sh
+++ b/scripts/sbc/add-broker.sh
@@ -11,7 +11,7 @@ source ${SBCDIR}/../env.sh
 
 (cd $SBCDIR/../security && ./certs-create-per-user.sh kafka3) || exit 1
 
-docker-compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml up -d kafka3
+docker compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml up -d kafka3
 
 # verify SBC responds with an add-broker balance plan
 MAX_WAIT=120

--- a/scripts/sbc/docker-compose.yml
+++ b/scripts/sbc/docker-compose.yml
@@ -1,15 +1,15 @@
-# docker-compose supports environment variable substitution with the ${VARIABLE-NAME} syntax.
+# docker compose supports environment variable substitution with the ${VARIABLE-NAME} syntax.
 # Environment variables can be sourced in a variety of ways.  One of those ways is through
 # a well known '.env' file located in the same folder as the docker-compose.yml file.  See the Docker
 # documentation for details: https://docs.docker.com/compose/environment-variables/#the-env-file
 # 
 # This feature is being used to parameterize some values within this file.  In this directory is also
 # a .env file, which is actually a symbolic link to <examples-root>/utils/config.env.  That file
-# contains values which get substituted here when docker-compose parses this file.
+# contains values which get substituted here when docker compose parses this file.
 #
 # If you'd like to view the docker-compose.yml file rendered with its environment variable substitutions
-# you can execute the `docker-compose config` command.  Take note that some demos provide additional 
-# environment variable values by exporting them in a script prior to running `docker-compose up`.
+# you can execute the `docker compose config` command.  Take note that some demos provide additional 
+# environment variable values by exporting them in a script prior to running `docker compose up`.
 ---
 version: "2.3"
 services:
@@ -26,7 +26,7 @@ services:
       - ./scripts/security/keypair:/tmp/conf
       - ./scripts/helper:/tmp/helper
       - ./scripts/security:/etc/kafka/secrets
-    command: "bash -c 'if [ ! -f /etc/kafka/secrets/kafka.kafka3.keystore.jks ]; then echo \"ERROR: Did not find SSL certificates in /etc/kafka/secrets/ (did you remember to run ./scripts/start.sh instead of docker-compose up -d?)\" && exit 1 ; else /etc/confluent/docker/run ; fi'"
+    command: "bash -c 'if [ ! -f /etc/kafka/secrets/kafka.kafka3.keystore.jks ]; then echo \"ERROR: Did not find SSL certificates in /etc/kafka/secrets/ (did you remember to run ./scripts/start.sh instead of docker compose up -d?)\" && exit 1 ; else /etc/confluent/docker/run ; fi'"
     ports:
       - 8093:8093
       - 9093:9093

--- a/scripts/sbc/validate_sbc_add_broker_completed.sh
+++ b/scripts/sbc/validate_sbc_add_broker_completed.sh
@@ -4,4 +4,4 @@ SBCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${SBCDIR}/../helper/functions.sh
 source ${SBCDIR}/../env.sh
 
-docker-compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml logs kafka1 kafka2 | grep "COMPLETED.*databalancer"
+docker compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml logs kafka1 kafka2 | grep "COMPLETED.*databalancer"

--- a/scripts/sbc/validate_sbc_add_broker_plan_computation.sh
+++ b/scripts/sbc/validate_sbc_add_broker_plan_computation.sh
@@ -4,4 +4,4 @@ SBCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${SBCDIR}/../helper/functions.sh
 source ${SBCDIR}/../env.sh
 
-docker-compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml logs kafka1 kafka2 | grep "PLAN_COMPUTATION.*databalancer"
+docker compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml logs kafka1 kafka2 | grep "PLAN_COMPUTATION.*databalancer"

--- a/scripts/sbc/validate_sbc_add_broker_reassignment.sh
+++ b/scripts/sbc/validate_sbc_add_broker_reassignment.sh
@@ -4,4 +4,4 @@ SBCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${SBCDIR}/../helper/functions.sh
 source ${SBCDIR}/../env.sh
 
-docker-compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml logs kafka1 kafka2 | grep "REASSIGNMENT.*databalancer"
+docker compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml logs kafka1 kafka2 | grep "REASSIGNMENT.*databalancer"

--- a/scripts/sbc/validate_sbc_kill_broker_completed.sh
+++ b/scripts/sbc/validate_sbc_kill_broker_completed.sh
@@ -4,6 +4,6 @@ SBCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${SBCDIR}/../helper/functions.sh
 source ${SBCDIR}/../env.sh
 
-docker-compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml logs kafka1 kafka2 | grep "BROKER_FAILURE.*execution finishes" || exit 1
-(docker-compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml exec kafka1 kafka-replica-status --bootstrap-server kafka1:9091 --admin.config /etc/kafka/secrets/client_sasl_plain.config --verbose || exit 1) | grep "IsInIsr: false" && exit 1
+docker compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml logs kafka1 kafka2 | grep "BROKER_FAILURE.*execution finishes" || exit 1
+(docker compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml exec kafka1 kafka-replica-status --bootstrap-server kafka1:9091 --admin.config /etc/kafka/secrets/client_sasl_plain.config --verbose || exit 1) | grep "IsInIsr: false" && exit 1
 exit 0

--- a/scripts/sbc/validate_sbc_kill_broker_started.sh
+++ b/scripts/sbc/validate_sbc_kill_broker_started.sh
@@ -4,4 +4,4 @@ SBCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${SBCDIR}/../helper/functions.sh
 source ${SBCDIR}/../env.sh
 
-docker-compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml logs kafka1 kafka2 | grep "BROKER_FAILURE.*started successfully"
+docker compose -f $SBCDIR/../../docker-compose.yml -f $SBCDIR/docker-compose.yml logs kafka1 kafka2 | grep "BROKER_FAILURE.*started successfully"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${DIR}/../env_files/config.env
 source ${DIR}/env.sh
 
-docker-compose down --volumes
+docker compose down --volumes
 
 cat << EOF
 

--- a/scripts/validate/validate_bindings.sh
+++ b/scripts/validate/validate_bindings.sh
@@ -32,7 +32,7 @@ CLIENT_PRINCIPAL="User:appSA"
 BADAPP="User:badapp"
 LISTEN_PRINCIPAL="User:clientListen"
 
-docker-compose exec tools bash -c ". /tmp/helper/functions.sh ; mds_login $MDS_URL ${SUPER_USER} ${SUPER_USER_PASSWORD}"
+docker compose exec tools bash -c ". /tmp/helper/functions.sh ; mds_login $MDS_URL ${SUPER_USER} ${SUPER_USER_PASSWORD}"
 
 ################################## Run through permutations #############################
 
@@ -40,7 +40,7 @@ for p in $SUPER_USER_PRINCIPAL $CONNECT_ADMIN $CONNECTOR_SUBMITTER $CONNECTOR_PR
   for c in " " " --schema-registry-cluster-id $SR" " --connect-cluster-id $CONNECT" " --ksql-cluster-id $KSQLDB"; do
     echo
     echo "Showing bindings for principal $p and --kafka-cluster-id $KAFKA_CLUSTER_ID $c"
-    docker-compose exec tools confluent iam rbac role-binding list --principal $p --kafka-cluster-id $KAFKA_CLUSTER_ID $c -o json
+    docker compose exec tools confluent iam rbac role-binding list --principal $p --kafka-cluster-id $KAFKA_CLUSTER_ID $c -o json
     echo
   done
 done

--- a/scripts/validate/validate_ksqldb_processing_log.sh
+++ b/scripts/validate/validate_ksqldb_processing_log.sh
@@ -2,14 +2,14 @@
 
 # Run "bad" query
 echo "Running 'bad' query (approximately 60 seconds)"
-docker-compose exec ksqldb-cli bash -c "ksql -u ksqlDBUser -p ksqlDBUser http://ksqldb-server:8088 << EOF
+docker compose exec ksqldb-cli bash -c "ksql -u ksqlDBUser -p ksqlDBUser http://ksqldb-server:8088 << EOF
 SELECT 1/0 FROM wikipedia EMIT CHANGES LIMIT 20;
 exit ;
 EOF"
 
 # Read from ksqlDB processing log
 echo "Reading from KSQL_PROCESSING_LOG (timeout 90 seconds)"
-docker-compose exec ksqldb-cli bash -c "timeout 90 ksql -u ksqlDBUser -p ksqlDBUser http://ksqldb-server:8088 << EOF
+docker compose exec ksqldb-cli bash -c "timeout 90 ksql -u ksqlDBUser -p ksqlDBUser http://ksqldb-server:8088 << EOF
 SET 'auto.offset.reset'='earliest';
 SET CLI COLUMN-WIDTH 20
 SELECT * FROM KSQL_PROCESSING_LOG EMIT CHANGES LIMIT 20;


### PR DESCRIPTION
### Description 

Compose has been a part of Docker for a while now and on Mac I wasn't able to install it standalone next to Docker. Simple aliasing wasn't good enough to pass cp-demo's preflight checks. Best path seemed to be to abandon standalone docker-compose.


### Author Validation

 - [x] Run cp-demo
