### PR TITLE
Fix KSQL-13533 for cp-demo - missing ksqlDB container monitoring-interceptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ ui/expanded
 kstreams-app/bin
 scripts/ccloud/cluster-link-cp.properties
 scripts/ccloud/schema-link.properties
+scripts/ksqlDB/monitoring-interceptors/**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -846,6 +846,7 @@ services:
       - ./scripts/security/keypair:/tmp/conf
       - ./scripts/helper:/tmp/helper
       - ./scripts/security:/etc/kafka/secrets
+      - ./scripts/ksqlDB/monitoring-interceptors/monitoring-interceptors.jar:/usr/share/java/ksqldb-server/monitoring-interceptors.jar
     ports:
       - 8088:8088
       - 8089:8089

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -88,6 +88,12 @@ docker-compose exec kafka1 kafka-configs \
 # Bring up more containers
 docker-compose up --no-recreate -d schemaregistry connect control-center
 
+# https://confluentinc.atlassian.net/browse/KSQL-13533 impacts CP 7.8.2 -> 7.9.x.
+# copy monitoring-interceptors from connect image to ksqlDB
+# remove this for CP 8.0+ where monitoring-interceptors are removed/deprecated
+docker cp connect:/usr/share/java/monitoring-interceptors scripts/ksqlDB/
+mv scripts/ksqlDB/monitoring-interceptors/monitoring-interceptors-*.jar scripts/ksqlDB/monitoring-interceptors/monitoring-interceptors.jar
+
 echo
 echo -e "Create topics in Kafka cluster:"
 docker-compose exec tools bash -c "/tmp/helper/create-topics.sh" || exit 1


### PR DESCRIPTION
### Description 

In KSQL-13533 the (deprecated) monitoring interceptors JAR is missing from ksqlDB Docker image.  This PR patches that for cp-demo by copying the file from Connect worker image.

This change won't apply for CP 8.0 where the monitoring interceptors are deprecated/removed.

### Author Validation

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [X] Run cp-demo
<!-- - [ ] jmx-monitoring-stacks -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] Run cp-demo -->
<!-- - [ ] jmx-monitoring-stacks -->
